### PR TITLE
[INLONG-4706][Website] Remove the "(incubating)" tag from the project name in the text content

### DIFF
--- a/community/how-to-become-a-committer.md
+++ b/community/how-to-become-a-committer.md
@@ -3,7 +3,7 @@ title: How to Become a Committer or PPMC
 sidebar_position: 4
 ---
 
-> [Apache InLong](https://inlong.apache.org)(incubating)is to build a community in full accordance with Apache’s rules. 
+> [Apache InLong](https://inlong.apache.org) is to build a community in full accordance with Apache’s rules. 
 > Apache Committer is a term used in ASF (Apache Software Foundation) to refer to people who submit specific projects.
 > Apache InLong Committer has the permission to write the InLong code base and can merge PR. 
 > Anyone who has made enough contributions to the community and gained enough trust can become an Apache InLong Committer.

--- a/community/how-to-contribute.md
+++ b/community/how-to-contribute.md
@@ -3,7 +3,7 @@ title: How to Contribute
 sidebar_position: 1
 ---
 
-The Apache InLong(incubating) community welcomes contributions from anyone with a passion for distributed systems! InLong has many different opportunities for contributions -- write new examples/tutorials, add new user-facing libraries or participate on the documentation effort.
+The Apache InLong community welcomes contributions from anyone with a passion for distributed systems! InLong has many different opportunities for contributions -- write new examples/tutorials, add new user-facing libraries or participate on the documentation effort.
 
 We use a review-then-commit workflow in InLong for all contributions.
 

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -46,7 +46,6 @@ export default function() {
           <div className="product-name">
             <div className="brandname">{dataSource.brand.brandName}</div>
             <div className="projectname" style={{backgroundImage: `url("${useBaseUrl('/img/inlong-en.svg')}"`}}>
-              {/* <img src="/static/img/incubating.svg"></img> */}
             </div>
           </div>
           <div className="product-desc2">


### PR DESCRIPTION
Fixes: https://github.com/apache/incubator-inlong/issues/4706

