### PR TITLE
[INLONG-518][Bug] The pgp server in release doc id deprecated and should upload connectors tar

### DIFF
--- a/community/how-to-release.md
+++ b/community/how-to-release.md
@@ -114,7 +114,7 @@ $ gpg --keyserver pgpkeys.mit.edu --send-key <key id>
 ```
 
 ### Check whether the key is created successfully
-Uploading takes about one minute, after that, you can check by your email at `http://keys.gnupg.net`. Be reminded to tick "the show full-key hashes" under advance.
+Uploading takes about one minute, after that, you can check by your email at `https://pgpkeys.mit.edu/`.
 
 
 ### Add your gpg public key to the KEYS document
@@ -222,6 +222,7 @@ cd /tmp/apache-inlong-${release_version}-${rc_version} # go to directory where t
 tar xzvf apache-inlong-${release_version}-src.tar.gz # uncompress the tar file
 cd apache-inlong-${release_version} # go to the source code directory
 cp ./inlong-distribution/target/apache-inlong-${release_version}-bin.tar.gz /tmp/apache-inlong-${release_version}-${rc_version}/  # for signature convenient, copy the binary package to the source code directory
+cp ./inlong-distribution/target/apache-inlong-${release_version}-sort-connectors.tar.gz /tmp/apache-inlong-${release_version}-${rc_version}/ # for signature convenient, copy the connectors binary package to the source code directory
 ```
 
 ### sign the source package/binary package/sha512

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/how-to-release.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/how-to-release.md
@@ -112,11 +112,8 @@ $ gpg --keyserver pgpkeys.mit.edu --send-key <key id>
 ```
 
 ### 查看 key 是否创建成功
-通过下面的网址，使用邮箱查询上传成功没，大概需要一分钟才能查到，查询时候把 advance 下边的 show full-key hashes 勾上
-http://keys.gnupg.net
-
-查询结果如下：
-
+通过下面的网址，使用邮箱查询上传成功没，大概需要一分钟才能查到
+https://pgpkeys.mit.edu/
 
 
 ### 将你的 gpg 公钥加入 KEYS 文件
@@ -235,6 +232,7 @@ tar xzvf apache-inlong-${release_version}-src.tar.gz #解压源码包
 cd apache-inlong-${release_version} # 进入源码目录
 mvn compile clean install package -DskipTests # 编译
 cp ./inlong-distribution/target/apache-inlong-${release_version}-bin.tar.gz /tmp/apache-inlong-${release_version}-${rc_version}/  # 拷贝二进制包拷到源码包目录下，方便下一步对包进行签名
+cp ./inlong-distribution/target/apache-inlong-${release_version}-sort-connectors.tar.gz /tmp/apache-inlong-${release_version}-${rc_version}/ # 拷贝connectors二进制包拷到源码包目录下，方便下一步对包进行签名
 ```
 
 ### 对源码包/二进制包进行签名/sha512


### PR DESCRIPTION
- Fixes #518 

### Motivation

[INLONG-518] [Bug] the pgp server in release doc id deprecated and should upload connectors tar

### Modifications

[INLONG-518] [Bug] the pgp server in release doc id deprecated and should upload connectors tar

### Verifying this change


### Documentation

  - Does this pull request introduce a new feature? (no)