### PR TITLE
[INLONG-633][Doc] Support running docker-compose on Arm Chip

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -11,7 +11,7 @@ Docker Compose deploys all components for Standard Architecture, and choose [Apa
 
 ## Environment Requirements
 - [Docker](https://docs.docker.com/engine/install/) 19.03.1+
-- Docker Compose 1.29.2+
+- Docker Compose 2.4+
 
 ## Download
 You can get `apache-inlong-[version]-bin.tar.gz` from [Download Page](https://inlong.apache.org/download) ,or you can build the InLong refer to [How to Build](quick_start/how_to_build.md).

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -11,7 +11,7 @@ Docker Compose deploys all components for Standard Architecture, and choose [Apa
 
 ## Environment Requirements
 - [Docker](https://docs.docker.com/engine/install/) 19.03.1+
-- Docker Compose 2.4+
+- [Docker Compose 2.4+](https://docs.docker.com/compose/install/other/#on-linux)
 
 ## Download
 You can get `apache-inlong-[version]-bin.tar.gz` from [Download Page](https://inlong.apache.org/download) ,or you can build the InLong refer to [How to Build](quick_start/how_to_build.md).

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/docker.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/docker.md
@@ -11,7 +11,7 @@ Docker Compose 部署了`标准架构`所需要的所有组件，使用 [Apache 
 
 ## 环境要求
 - [Docker](https://docs.docker.com/engine/install/) 19.03.1+
-- Docker Compose 2.4+
+- [Docker Compose 2.4+](https://docs.docker.com/compose/install/other/#on-linux)
 
 ## 下载
 你可以从 [下载页面](https://inlong.apache.org/zh-CN/download/) 获取 `apache-inlong-[version]-bin.tar.gz`，或者参考 [How to Build](quick_start/how_to_build.md) 编译。

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/docker.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/docker.md
@@ -11,7 +11,7 @@ Docker Compose 部署了`标准架构`所需要的所有组件，使用 [Apache 
 
 ## 环境要求
 - [Docker](https://docs.docker.com/engine/install/) 19.03.1+
-- Docker Compose 1.29.2+
+- Docker Compose 2.4+
 
 ## 下载
 你可以从 [下载页面](https://inlong.apache.org/zh-CN/download/) 获取 `apache-inlong-[version]-bin.tar.gz`，或者参考 [How to Build](quick_start/how_to_build.md) 编译。


### PR DESCRIPTION
### Description

### Support running docker-compose on Arm Chip

Fixes #633 


### Motivation

Specify the `--platform` parameter of the `MySQL` image.
Update version of `docker-compose` to `2.4+`

### Modifications

By modifying the `--platform` parameter of the `MySQL` image, it can simulate `x86` instructions to build a docker image under different system architectures, and only need the same `docker-compose` script

In order to support compatible chip solutions, you need to update the docker-compose version to 2.4+

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Use case

_No response_

### Are you willing to submit PR?

- [X] Yes, I am willing to submit a PR!

### Code of Conduct

- [X] I agree to follow this project's [Code of Conduct](https://www.apache.org/foundation/policies/conduct)
