### PR TITLE
[INLONG-702][Doc] Remove unsupported options in MongoDB CDC 2.3

### DIFF
--- a/docs/data_node/extract_node/mongodb-cdc.md
+++ b/docs/data_node/extract_node/mongodb-cdc.md
@@ -125,11 +125,7 @@ TODO: It will be supported in the future.
 | database                  | required     | (none)           | String   | Name of the database to watch for changes.                   |
 | collection                | required     | (none)           | String   | Name of the collection in the database to watch for changes. |
 | connection.options        | optional     | (none)           | String   | The ampersand-separated [connection options](https://docs.mongodb.com/manual/reference/connection-string/#std-label-connections-connection-options) of MongoDB. eg. `replicaSet=test&connectTimeoutMS=300000` |
-| errors.tolerance          | optional     | none             | String   | Whether to continue processing messages if an error is encountered. Accept `none` or `all`. When set to `none`, the connector reports an error and blocks further processing of the rest of the records when it encounters an error. When set to `all`, the connector silently ignores any bad messages. |
-| errors.log.enable         | optional     | true             | Boolean  | Whether details of failed operations should be written to the log file. |
 | copy.existing             | optional     | true             | Boolean  | Whether copy existing data from source collections.          |
-| copy.existing.pipeline    | optional     | (none)           | String   | An array of JSON objects describing the pipeline operations to run when copying existing data. This can improve the use of indexes by the copying manager and make copying more efficient. eg. `[{"$match": {"closed": "false"}}]` ensures that only documents in which the closed field is set to false are copied. |
-| copy.existing.max.threads | optional     | Processors Count | Integer  | The number of threads to use when performing the data copy.  |
 | copy.existing.queue.size  | optional     | 16000            | Integer  | The max size of the queue to use when copying data.          |
 | poll.max.batch.size       | optional     | 1000             | Integer  | Maximum number of change stream documents to include in a single batch when polling for new data. |
 | poll.await.time.ms        | optional     | 1500             | Integer  | The amount of time to wait before checking for new results on the change stream. |

--- a/docs/data_node/extract_node/mongodb-cdc.md
+++ b/docs/data_node/extract_node/mongodb-cdc.md
@@ -126,9 +126,9 @@ TODO: It will be supported in the future.
 | collection                | required     | (none)           | String   | Name of the collection in the database to watch for changes. |
 | connection.options        | optional     | (none)           | String   | The ampersand-separated [connection options](https://docs.mongodb.com/manual/reference/connection-string/#std-label-connections-connection-options) of MongoDB. eg. `replicaSet=test&connectTimeoutMS=300000` |
 | copy.existing             | optional     | true             | Boolean  | Whether copy existing data from source collections.          |
-| copy.existing.queue.size  | optional     | 16000            | Integer  | The max size of the queue to use when copying data.          |
-| poll.max.batch.size       | optional     | 1000             | Integer  | Maximum number of change stream documents to include in a single batch when polling for new data. |
-| poll.await.time.ms        | optional     | 1500             | Integer  | The amount of time to wait before checking for new results on the change stream. |
+| copy.existing.queue.size  | optional     | 10240            | Integer  | The max size of the queue to use when copying data.          |
+| poll.max.batch.size       | optional     | 1024             | Integer  | Maximum number of change stream documents to include in a single batch when polling for new data. |
+| poll.await.time.ms        | optional     | 1000             | Integer  | The amount of time to wait before checking for new results on the change stream. |
 | heartbeat.interval.ms     | optional     | 0                | Integer  | The length of time in milliseconds between sending heartbeat messages. Use 0 to disa |
 | inlong.metric.labels | optional | (none) | String | Inlong metric label, format of value is groupId=`{groupId}`&streamId=`{streamId}`&nodeId=`{nodeId}`. |
 ## Available Metadata

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/mongodb-cdc.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/mongodb-cdc.md
@@ -126,9 +126,9 @@ TODO: 未来会支持
 | collection                | 必须         | (none)     | String   | 数据库中要监视更改的集合的名称。                             |
 | connection.options        | 可选         | (none)     | String   | MongoDB的 & 分隔[连接选项](https://docs.mongodb.com/manual/reference/connection-string/#std-label-connections-connection-options)。例如。`replicaSet=test&connectTimeoutMS=300000` |
 | copy.existing             | 可选         | true       | Boolean  | 是否从源集合中复制现有数据。                                 |
-| copy.existing.queue.size  | 可选         | 16000      | Integer  | 执行数据复制时使用的线程数。                                 |
-| poll.max.batch.size       | 可选         | 1000       | Integer  | 轮询新数据时，单个批次中包含的最大更改流文档数。             |
-| poll.await.time.ms        | 可选         | 1500       | Integer  | 在更改流上检查新结果之前等待的时间量。                       |
+| copy.existing.queue.size  | 可选         | 10240      | Integer  | 执行数据复制时使用的线程数。                                 |
+| poll.max.batch.size       | 可选         | 1024       | Integer  | 轮询新数据时，单个批次中包含的最大更改流文档数。             |
+| poll.await.time.ms        | 可选         | 1000       | Integer  | 在更改流上检查新结果之前等待的时间量。                       |
 | heartbeat.interval.ms     | 可选         | 0          | Integer  | 发送心跳消息之间的时间长度（以毫秒为单位）。使用 0 禁用。    |
 | inlong.metric.labels             | 可选         | (none)     | String   | inlong metric 的标签值，该值的构成为groupId=`{groupId}`&streamId=`{streamId}`&nodeId=`{nodeId}`。|
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/mongodb-cdc.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/mongodb-cdc.md
@@ -125,11 +125,7 @@ TODO: 未来会支持
 | database                  | 必须         | (none)     | String   | 要监视更改的数据库的名称。                                   |
 | collection                | 必须         | (none)     | String   | 数据库中要监视更改的集合的名称。                             |
 | connection.options        | 可选         | (none)     | String   | MongoDB的 & 分隔[连接选项](https://docs.mongodb.com/manual/reference/connection-string/#std-label-connections-connection-options)。例如。`replicaSet=test&connectTimeoutMS=300000` |
-| errors.tolerance          | 可选         | none       | String   | 如果遇到错误，是否继续处理消息。接受`none`或`all`。设置为`none`时，连接器会报告错误并在遇到错误时阻止对其余记录的进一步处理。设置为`all`时，连接器会静默忽略任何错误消息。 |
-| errors.log.enable         | 可选         | true       | Boolean  | 是否应将失败操作的详细信息写入日志文件。                     |
 | copy.existing             | 可选         | true       | Boolean  | 是否从源集合中复制现有数据。                                 |
-| copy.existing.pipeline    | 可选         | (none)     | String   | 一组 JSON 对象，描述在复制现有数据时要运行的管道操作。这可以提高复制管理器对索引的使用，并使复制更有效。例如。`[{"$match": {"closed": "false"}}]`确保仅复制已关闭字段设置为 false 的文档。 |
-| copy.existing.max.threads | 可选         | 处理器数量 | Integer  | 执行数据复制时使用的线程数。                                 |
 | copy.existing.queue.size  | 可选         | 16000      | Integer  | 执行数据复制时使用的线程数。                                 |
 | poll.max.batch.size       | 可选         | 1000       | Integer  | 轮询新数据时，单个批次中包含的最大更改流文档数。             |
 | poll.await.time.ms        | 可选         | 1500       | Integer  | 在更改流上检查新结果之前等待的时间量。                       |


### PR DESCRIPTION
### Prepare a Pull Request

Remove unsupported options in MongoDB CDC 2.3

- Fixes #702 

### Motivation

Some options have been removed in MongoDB CDC 2.3, for details please refer to this PR https://github.com/apache/inlong/pull/7515.

### Modifications

Remove the following options.

```
errors.tolerance
errors.log.enable
copy.existing.pipeline
copy.existing.max.threads
```