### PR TITLE
[INLONG-727][Doc] Dirty data archiving options description for StarRocks connector

### DIFF
--- a/docs/data_node/load_node/starrocks.md
+++ b/docs/data_node/load_node/starrocks.md
@@ -64,7 +64,7 @@ mysql> select * from cdc_mysql_source;
 +----+----------+----+
 3 rows in set (0.07 sec)
 ```
-- For Multi-sink: Create tables `user_db.user_id_name`、`user_db.user_id_name` in the MySQL database. The command is as follows:
+- For Multi-sink: Create tables `user_db.user_id_name`、`user_db.user_id_score` in the MySQL database. The command is as follows:
 ```sql
 [root@fe001 ~]# mysql -u root -h localhost -P 3306 -p123456
 mysql> use user_db;

--- a/docs/data_node/load_node/starrocks.md
+++ b/docs/data_node/load_node/starrocks.md
@@ -296,6 +296,22 @@ TODO: It will be supported in the future.
 | sink.multiple.database-pattern    | optional   | (none)            | string   | Extract database name from the raw binary data, this is only used in the multiple sink writing scenario.                 | 
 | sink.multiple.table-pattern       | optional   | (none)            | string   | Extract table name from the raw binary data, this is only used in the multiple sink writing scenario. |
 | inlong.metric.labels | optional | (none) | String | Inlong metric label, format of value is groupId=`{groupId}`&streamId=`{streamId}`&nodeId=`{nodeId}`. |
+| sink.multiple.schema-update.policy | optional | (none) | string | If sink data fields do not match starrocks table, such as table does not exsit or string data is over length, starrocks server will throw an exception.<br /><br /> When this option is `THROW_WITH_STOP`, the exception will be thrown up to flink framework, flink will restart task automatically, trying to resume the task.<br /><br /> When this option is `STOP_PARTIAL`, starrocks connector will stop writing into this table, other tables are written normally. The exception will be logging but not thrown up.<br /><br /> When this option is `LOG_WITH_IGNORE`, starrocks connector only log the error, not throw up. StarRocks connector will try to write to starrocks server again when receiving new source data. |
+| dirty.ignore | optinal | (none)| boolean | When writing data into starrocks table, errors may be thrown by starrocks server as table does not exist or data is over length. <br /><br /> When this option is `true`, and `dirty.side-output.*` properties are configed correctly, dirty data can be written to Amazon S3 or Tencent Colud COS storage. Dirty data metrics will also be collected automatically. <br /><br /> When this option is `false`, only dirty data metrics will be collected, but dirty data will not be archived. |
+| dirty.side-output.enable | optinal | (none)| boolean | When this option is `ture` and other options about S3 or COS is configed correctly, dirty data archiving will works. When `false`, dirty data archiving will not work. |
+| dirty.side-output.connector | optinal | (none)| string | `s3` or `log` are supported now.<br /><br /> When `log`, starrocks connector only log the dirty data, not archive data.<br /><br /> When `s3`, starrocks connector can write dirty data to S3 or COS. |
+| dirty.side-output.s3.bucket | optinal | (none)| string | The bucket name of S3 or COS |
+| dirty.side-output.s3.endpoint | optinal | (none)| string | The endpoint of S3 or COS |
+| dirty.side-output.s3.key | optinal | (none)| string | The key of S3 or COS  |
+| dirty.side-output.s3.region | optinal | (none)| string | The region of S3 or COS |
+| dirty.side-output.line-delimiter | optinal | (none)| string | The line delimiter of dirty data |
+| dirty.side-output.field-delimiter | optinal | (none)| string | The field delimiter of dirty data |
+| dirty.side-output.s3.secret-key-id | optinal | (none)| string | The secret key of S3 or COS |
+| dirty.side-output.s3.access-key-id | optinal | (none)| string | The access key of S3 or COS |
+| dirty.side-output.format | optinal | (none)| string | The format of dirty data archiving, supports `json` or `csv` |
+| dirty.side-output.log-tag | optinal | (none)| string | The log tag of dirty data. StarRocks connector uses lags to distinguish which starrocks database and table the dirty data will be written to. |
+| dirty.identifier | optinal | (none)| string | The file name of drity data which written to S3 or COS. |
+| dirty.side-output.labels | optinal | (none)| string | Every dirty data line contains label and business data fields. Label is in front, and business data is at end. |
 
 ## Data Type Mapping
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/load_node/starrocks.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/load_node/starrocks.md
@@ -293,6 +293,21 @@ TODO: 将在未来支持此功能。
 | sink.multiple.database-pattern    | 可选     | 无               | string   | 从原始二进制数据中提取数据库名，仅在多表(整库)同步场景中使用。 | 
 | sink.multiple.table-pattern       | 可选     | 无               | string   | 从原始二进制数据中提取表名，仅在多表(整库)同步场景中使用。 |
 | inlong.metric.labels | 可选 | (none) | String | inlong metric 的标签值，该值的构成为groupId=`{groupId}`&streamId=`{streamId}`&nodeId=`{nodeId}`。|
+| sink.multiple.schema-update.policy | 可选 | (none) | string | 往StarRocks表同步数据时，如果StarRocks表不存在或字段长度超过限制，StarRocks服务器会抛出异常。<br /><br /> 当该属性设置为`THROW_WITH_STOP`，异常会向上抛给Flink框架。Flink框架会自动重启任务，尝试恢复。<br /><br /> 当该属性设置为`STOP_PARTIAL`时，StarRocks connector会忽略该表的写入，新数据不再往该表写入，其它表则正常同步。<br /><br /> 当该属性设置为`LOG_WITH_IGNORE`时，异常会打印到日志中，不会向上抛出。后续新数据到来时，继续尝试往该表写入。 |
+| dirty.ignore | 可选 | (none)| boolean | 往StarRocks表同步数据时，如果遇到错误和异常，通过该变量可以控制是否忽略脏数据。如果设置为`false`，则忽略脏数据，不归档。如果为`true`，则根据其它的`dirty.side-output.*`的配置决定如何归档数据。 |
+| dirty.side-output.connector | 可选 | (none)| string | 支持`s3`和`log`两种配置。当配置为`log`时，仅打印日志，不归档数据。当配置为`s3`时，可以将数据归档到亚马逊S3或腾讯云COS存储。 |
+| dirty.side-output.s3.bucket | 可选 | (none)| string | S3或COS的桶名称 |
+| dirty.side-output.s3.endpoint | 可选 | (none)| string | S3或COS的endpoint地址 |
+| dirty.side-output.s3.key | 可选 | (none)| string | S3或COS的key  |
+| dirty.side-output.s3.region | 可选 | (none)| string | S3或COS的区域 |
+| dirty.side-output.line-delimiter | 可选 | (none)| string | 脏数据的行分隔符 |
+| dirty.side-output.field-delimiter | 可选 | (none)| string | 脏数据的字段分隔符 |
+| dirty.side-output.s3.secret-key-id | 可选 | (none)| string | S3或COS的secret key |
+| dirty.side-output.s3.access-key-id | 可选 | (none)| string | S3或COS的access key |
+| dirty.side-output.format | 可选 | (none)| string | 脏数据归档的格式，支持 `json` 和 `csv` |
+| dirty.side-output.log-tag | 可选 | (none)| string | 脏数据的tag。通过该变量区分每条脏数据归属于StarRocks的哪个库表。 |
+| dirty.identifier | 可选 | (none)| string | 归档后的文件名 |
+| dirty.side-output.labels | 可选 | (none)| string | 归档后的每条数据包括标签和业务数据两部分。标签在前面，业务数据在后面。 |
 
 ## 数据类型映射
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/load_node/starrocks.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/load_node/starrocks.md
@@ -271,24 +271,24 @@ TODO: 将在未来支持此功能。
 
 | 参数                               | 是否必选  | 默认值            | 数据类型  | 描述     |
 | --------------------------------- | ------- | ----------------- | ------- | ------- |
-| connector                         | 必选     | 无                | string  | 指定使用哪个connector，合法值为`starrocks-inlong` |
-| jdbc-url                          | 必选     | 无                | string  | 用于在starrocks中执行查询 |                  
-| load-url                          | 必选     | 无                | string  | 格式为 fe_ip:http_port;fe_ip:http_port 用分号(;)隔开。用于向starrocks批量写入数据。|                                                 
-| database-name                     | 必选     | 无                | string  | starrocks的数据库名 |
-| table-name                        | 必选     | 无                | string  | starrocks的表名 |
-| username                          | 必选     | 无                | string  | starrocks连接的用户名 |
-| password                          | 必选     | 无                | string  | starrocks连接的口令 |
-| sink.semantic                     | 可选     | at-least-once    | string  | 可选值为 at-least-once 或 exactly-once (仅在checkpoint时刷新数据，`sink.buffer-flush.*` 等参数将不再工作) |
-| sink.version                      | 可选     | AUTO             | string  | exectly-once语义的实现版本，只有connector在1.2.4及以上的版本时才可用。如果填V2，则使用StarRocks的stream load事务接口需要2.4及以上的StarRocks版本。如果填V1，则使用stream load非事务接口。如果填AUTO，则connector根据StarRocks是否支持事务的特性来自动选择stream load的事务接口。 |
+| connector                         | 必选     | 无                | string  | 指定使用哪个 connector ，合法值为 `starrocks-inlong` |
+| jdbc-url                          | 必选     | 无                | string  | 用于在 StarRocks 中执行查询 |                  
+| load-url                          | 必选     | 无                | string  | 格式为 fe_ip:http_port;fe_ip:http_port 用分号(;)隔开。用于向 StarRocks 批量写入数据。|                                                 
+| database-name                     | 必选     | 无                | string  | StarRocks 的数据库名 |
+| table-name                        | 必选     | 无                | string  | StarRocks 的表名 |
+| username                          | 必选     | 无                | string  | StarRocks 连接的用户名 |
+| password                          | 必选     | 无                | string  | StarRocks 连接的口令 |
+| sink.semantic                     | 可选     | at-least-once    | string  | 可选值为 at-least-once 或 exactly-once (仅在 checkpoint 时刷新数据，`sink.buffer-flush.*` 等参数将不再工作) |
+| sink.version                      | 可选     | AUTO             | string  | exectly-once语义的实现版本，只有 connector 在1.2.4及以上的版本时才可用。如果填 V2，则使用 StarRocks 的 stream load 事务接口需要 2.4 及以上的 StarRocks 版本。如果填 V1，则使用 stream load 非事务接口。如果填 AUTO，则 connector 根据 StarRocks 是否支持事务的特性来自动选择 stream load 的事务接口。 |
 | sink.buffer-flush.max-bytes       | 可选     | 94371840(90M)    | string  | 批量刷新缓存数据的大小阈值，范围：[64MB, 10GB] |
 | sink.buffer-flush.max-rows        | 可选     | 500000           | string  | 批量刷新缓存数据的行数阈值，范围：[64,000, 5000,000] |
 | sink.buffer-flush.interval-ms     | 可选     | 300000           | string  | 批量刷新缓存数据的时间间隔，范围：[1000ms, 3600000ms] |
-| sink.max-retries                  | 可选     | 3                | string  | stream load请求的最大重试次数，范围：[0, 10] |
-| sink.connect.timeout-ms           | 可选     | 1000             | string  | 连接到指定的load-url的超时时间，单位：毫秒，范围：[100, 60000] |
-| sink.properties.format            | 可选     | CSV              | string  | 导入到starocks的数据文件格式，可选的值为：CSV和JSON。默认为: CSV |
-| sink.properties.*                 | 可选     | 无                | string  | stream load的属性，例如：'sink.properties.columns' = 'k1, k2, k3'。从StarRocks 2.4开始，flink-connector-starrocks支持Primary Key模式下的数据部分更新。 |
-| sink.properties.ignore_json_size  | 可选     | false            | string  |  忽略json数据的批量大小限制(100MB) | 
-| sink.multiple.enable              | 可选     | false            | boolean | 决定是否开始多表(整库)写入特性，默认为`false`。当 `sink.multiple.enable` 为 `true` 时，也需要设置 `sink.multiple.format`、 `sink.multiple.database-pattern` 和 `sink.multiple.table-pattern` |
+| sink.max-retries                  | 可选     | 3                | string  | Stream load 请求的最大重试次数，范围：[0, 10] |
+| sink.connect.timeout-ms           | 可选     | 1000             | string  | 连接到指定的 load-url 的超时时间，单位：毫秒，范围：[100, 60000] |
+| sink.properties.format            | 可选     | CSV              | string  | 导入到 StarRocks 的数据文件格式，可选的值为：CSV 和 JSON 。默认为: CSV |
+| sink.properties.*                 | 可选     | 无                | string  | Stream load 的属性，例如：'sink.properties.columns' = 'k1, k2, k3'。从 StarRocks 2.4 开始，flink-connector-starrocks 支持 Primary Key 模式下的数据部分更新。 |
+| sink.properties.ignore_json_size  | 可选     | false            | string  |  忽略 json 数据的批量大小限制(100MB) | 
+| sink.multiple.enable              | 可选     | false            | boolean | 决定是否开始多表(整库)写入特性，默认为 `false` 。当 `sink.multiple.enable` 为 `true` 时，也需要设置 `sink.multiple.format`、 `sink.multiple.database-pattern` 和 `sink.multiple.table-pattern` |
 | sink.multiple.format              | 可选     | 无               | string   | 多表(整库)写入的数据格式，它表示 connector 之间流转的原始二进制数据的实际格式，目前支持 `canal-json` 和 `debezium-json` 。可以查看 [kafka -- Dynamic Topic Extraction](https://github.com/apache/inlong-website/blob/master/docs/data_node/load_node/kafka.md)获取更多信息。  |
 | sink.multiple.database-pattern    | 可选     | 无               | string   | 从原始二进制数据中提取数据库名，仅在多表(整库)同步场景中使用。 | 
 | sink.multiple.table-pattern       | 可选     | 无               | string   | 从原始二进制数据中提取表名，仅在多表(整库)同步场景中使用。 |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/load_node/starrocks.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/load_node/starrocks.md
@@ -288,24 +288,24 @@ TODO: 将在未来支持此功能。
 | sink.properties.format            | 可选     | CSV              | string  | 导入到starocks的数据文件格式，可选的值为：CSV和JSON。默认为: CSV |
 | sink.properties.*                 | 可选     | 无                | string  | stream load的属性，例如：'sink.properties.columns' = 'k1, k2, k3'。从StarRocks 2.4开始，flink-connector-starrocks支持Primary Key模式下的数据部分更新。 |
 | sink.properties.ignore_json_size  | 可选     | false            | string  |  忽略json数据的批量大小限制(100MB) | 
-| sink.multiple.enable              | 可选     | false            | boolean | 决定是否开始多表(整库)写入特性，默认为`false`。当 `sink.multiple.enable` 为 `true` 时，也需要设置 `sink.multiple.format`、`sink.multiple.database-pattern`和`sink.multiple.table-pattern` |
-| sink.multiple.format              | 可选     | 无               | string   | 多表(整库)写入的数据格式，它表示connector之间流转的原始二进制数据的实际格式，目前支持`canal-json` 和 `debezium-json`。可以查看[kafka -- Dynamic Topic Extraction](https://github.com/apache/inlong-website/blob/master/docs/data_node/load_node/kafka.md)获取更多信息。  |
+| sink.multiple.enable              | 可选     | false            | boolean | 决定是否开始多表(整库)写入特性，默认为`false`。当 `sink.multiple.enable` 为 `true` 时，也需要设置 `sink.multiple.format`、 `sink.multiple.database-pattern` 和 `sink.multiple.table-pattern` |
+| sink.multiple.format              | 可选     | 无               | string   | 多表(整库)写入的数据格式，它表示 connector 之间流转的原始二进制数据的实际格式，目前支持 `canal-json` 和 `debezium-json` 。可以查看 [kafka -- Dynamic Topic Extraction](https://github.com/apache/inlong-website/blob/master/docs/data_node/load_node/kafka.md)获取更多信息。  |
 | sink.multiple.database-pattern    | 可选     | 无               | string   | 从原始二进制数据中提取数据库名，仅在多表(整库)同步场景中使用。 | 
 | sink.multiple.table-pattern       | 可选     | 无               | string   | 从原始二进制数据中提取表名，仅在多表(整库)同步场景中使用。 |
-| inlong.metric.labels | 可选 | (none) | String | inlong metric 的标签值，该值的构成为groupId=`{groupId}`&streamId=`{streamId}`&nodeId=`{nodeId}`。|
-| sink.multiple.schema-update.policy | 可选 | (none) | string | 往StarRocks表同步数据时，如果StarRocks表不存在或字段长度超过限制，StarRocks服务器会抛出异常。<br /><br /> 当该属性设置为`THROW_WITH_STOP`，异常会向上抛给Flink框架。Flink框架会自动重启任务，尝试恢复。<br /><br /> 当该属性设置为`STOP_PARTIAL`时，StarRocks connector会忽略该表的写入，新数据不再往该表写入，其它表则正常同步。<br /><br /> 当该属性设置为`LOG_WITH_IGNORE`时，异常会打印到日志中，不会向上抛出。后续新数据到来时，继续尝试往该表写入。 |
-| dirty.ignore | 可选 | (none)| boolean | 往StarRocks表同步数据时，如果遇到错误和异常，通过该变量可以控制是否忽略脏数据。如果设置为`false`，则忽略脏数据，不归档。如果为`true`，则根据其它的`dirty.side-output.*`的配置决定如何归档数据。 |
-| dirty.side-output.connector | 可选 | (none)| string | 支持`s3`和`log`两种配置。当配置为`log`时，仅打印日志，不归档数据。当配置为`s3`时，可以将数据归档到亚马逊S3或腾讯云COS存储。 |
-| dirty.side-output.s3.bucket | 可选 | (none)| string | S3或COS的桶名称 |
-| dirty.side-output.s3.endpoint | 可选 | (none)| string | S3或COS的endpoint地址 |
-| dirty.side-output.s3.key | 可选 | (none)| string | S3或COS的key  |
-| dirty.side-output.s3.region | 可选 | (none)| string | S3或COS的区域 |
+| inlong.metric.labels | 可选 | (none) | String | inlong metric 的标签值，该值的构成为 groupId=`{groupId}`&streamId=`{streamId}`&nodeId=`{nodeId}`。|
+| sink.multiple.schema-update.policy | 可选 | (none) | string | 往 StarRocks 表同步数据时，如果 StarRocks 表不存在或字段长度超过限制，StarRocks 服务器会抛出异常。<br /><br /> 当该属性设置为 `THROW_WITH_STOP`，异常会向上抛给 Flink 框架。Flink 框架会自动重启任务，尝试恢复。<br /><br /> 当该属性设置为 `STOP_PARTIAL` 时，StarRocks connector 会忽略该表的写入，新数据不再往该表写入，其它表则正常同步。<br /><br /> 当该属性设置为 `LOG_WITH_IGNORE` 时，异常会打印到日志中，不会向上抛出。后续新数据到来时，继续尝试往该表写入。 |
+| dirty.ignore | 可选 | (none)| boolean | 往 StarRocks 表同步数据时，如果遇到错误和异常，通过该变量可以控制是否忽略脏数据。如果设置为 `false` ，则忽略脏数据，不归档。如果为 `true` ，则根据其它的 `dirty.side-output.*` 的配置决定如何归档数据。 |
+| dirty.side-output.connector | 可选 | (none)| string | 支持 `s3` 和 `log` 两种配置。当配置为 `log` 时，仅打印日志，不归档数据。当配置为 `s3` 时，可以将数据归档到亚马逊 S3 或腾讯云 COS 存储。 |
+| dirty.side-output.s3.bucket | 可选 | (none)| string | S3 或 COS 的桶名称 |
+| dirty.side-output.s3.endpoint | 可选 | (none)| string | S3 或 COS 的 endpoint 地址 |
+| dirty.side-output.s3.key | 可选 | (none)| string | S3 或 COS 的 key  |
+| dirty.side-output.s3.region | 可选 | (none)| string | S3 或 COS 的区域 |
 | dirty.side-output.line-delimiter | 可选 | (none)| string | 脏数据的行分隔符 |
 | dirty.side-output.field-delimiter | 可选 | (none)| string | 脏数据的字段分隔符 |
-| dirty.side-output.s3.secret-key-id | 可选 | (none)| string | S3或COS的secret key |
-| dirty.side-output.s3.access-key-id | 可选 | (none)| string | S3或COS的access key |
+| dirty.side-output.s3.secret-key-id | 可选 | (none)| string | S3 或 COS 的 secret key |
+| dirty.side-output.s3.access-key-id | 可选 | (none)| string | S3 或 COS 的 access key |
 | dirty.side-output.format | 可选 | (none)| string | 脏数据归档的格式，支持 `json` 和 `csv` |
-| dirty.side-output.log-tag | 可选 | (none)| string | 脏数据的tag。通过该变量区分每条脏数据归属于StarRocks的哪个库表。 |
+| dirty.side-output.log-tag | 可选 | (none)| string | 脏数据的 tag 。通过该变量区分每条脏数据归属于 StarRocks 的哪个库表。 |
 | dirty.identifier | 可选 | (none)| string | 归档后的文件名 |
 | dirty.side-output.labels | 可选 | (none)| string | 归档后的每条数据包括标签和业务数据两部分。标签在前面，业务数据在后面。 |
 


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #727

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

There are some dirty data archiving options for StarRocks connector. Such as `dirty.igore`, `dirty.side-output.connector` and `dirty.side-output.labels` etc. The PR shows how to use them.

### Modifications

*Describe the modifications you've done.*

The English and Chinese document for Doris connector.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
