### PR TITLE
[INLONG-754][Doc] Download page 1.7.0 'Release Date' error

### DIFF
--- a/src/pages/downloads/index.js
+++ b/src/pages/downloads/index.js
@@ -6,7 +6,7 @@ import Translate, { translate } from '@docusaurus/Translate';
 export default function() {
 
     const version = "1.7.0";
-    const date = "May. 23, 2023";
+    const date = "May. 19, 2023";
 
     return (
         <Layout title={translate({ message: 'Downloads' })}>


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #754 

### Motivation

Download page 1.7.0 'Release Date' error

### Modifications

Modify the date property in src/pages/downloads/index.js


### Verifying this change

![WX20230523-003023](https://github.com/apache/inlong-website/assets/1780095/c076eb2e-d16f-46f1-858c-ddb3c3cf966e)

