### PR TITLE
[INLONG-WEBSITE-764][DataProxy] Add Golang SDK documents

### DIFF
--- a/docs/sdk/dataproxy-sdk/go.md
+++ b/docs/sdk/dataproxy-sdk/go.md
@@ -35,7 +35,7 @@ if err != nil {
 where:
 
 - `dataproxy.WithGroupID("test")` sets the GroupID;
-- `dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList")` sets the service registry URL;
+- `dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList")` sets the Manager URL;
 - `dataproxy.WithMetricsName("test")` sets the value of the metrics label: "name" of the `Client`.
 
 ### Call the Send/SendAsync method to send
@@ -106,9 +106,9 @@ Some common errors:
 
 | Error                                                       | Desc                                       |
 | ------------------------------------------------------------ | ------------------------------------------- |
-| errors.New("URL is not given")                               | Service registry URL is not set.                                |
+| errors.New("URL is not given")                               | Manager URL is not set.                                |
 | errors.New("group ID is not given")                          | Group ID is not set.                                |
-| errors.New("invalid URL")                                    | Service registry URL is invalid.                            |
+| errors.New("invalid URL")                                    | Manager URL is invalid.                            |
 | errors.New("invalid group ID")                               | Group ID is invalid.                                |
 | errors.New("service has no endpoints")                       | Service has no endpoints, service discoery failed.                        |
 | errors.New("no available worker")                            | No available workers, workers are busy.                              |
@@ -125,7 +125,7 @@ Some common errors:
 | --------------------------- | ---------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | WithSet()                   | ""                           | Sets the cluster name.                                        | Yes, no use now.                                                   |
 | WithGroupID()               | ""                           | Sets the Group ID.                                            | No                                                           |
-| WithURL()                   | ""                           | Sets the service registry URL.                                | No                                                           |
+| WithURL()                   | ""                           | Sets the Manager URL.                                | No                                                           |
 | WithUpdateInterval()        | 5m                           | Sets the update interval of service discoery.                 | Yes                                                           |
 | WithConnTimeout()           | 3000ms                       | Sets the connection timeout.                                  | Yes                                                           |
 | WriteBufferSize             | 16M                          | Sets the write buffer size.                                   | Yes                                                           |

--- a/docs/sdk/dataproxy-sdk/go.md
+++ b/docs/sdk/dataproxy-sdk/go.md
@@ -32,7 +32,7 @@ if err != nil {
 }
 ```
 
-where:
+Parameters:
 
 - `dataproxy.WithGroupID("test")` sets the GroupID;
 - `dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList")` sets the Manager URL;

--- a/docs/sdk/dataproxy-sdk/go.md
+++ b/docs/sdk/dataproxy-sdk/go.md
@@ -1,21 +1,17 @@
 ---
-title: Go SDK
+title: Golang SDK
 sidebar_position: 4
 ---
-
-import {siteVariables} from '../../version';
 
 ## Create real-time synchronization task
 Create a task on the Dashboard or with the command line tool, and set `Auto Push` (autonomous push) as the data source type.
 
-## Import Go SDK
-To use the Go SDK, you need to import it into your projects. Import the Go SDK:
+## Import Golang SDK
+To use the Golang SDK, you need to import it into your projects. Import the Golang SDK:
 
 ```go
 import "github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy"
 ```
-
-
 
 
 ## Data report process
@@ -36,7 +32,14 @@ if err != nil {
 }
 ```
 
+where:
+
+- dataproxy.WithGroupID("test") sets the GroupID;
+- dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList") sets the service registry URL;
+- dataproxy.WithMetricsName("test") sets the value of the metrics label: "name" of the `Client`.
+
 ### Call the Send/SendAsync method to send
+
 The send methods of the SDK are goroutine safe, you can send a message synchronously or asynchronously, there are both synchronous and asynchronous examples in the demo.
 
 Send synchronously :
@@ -90,9 +93,7 @@ Closing the SDK can be done simply by calling the  `Close()` method of the `Clie
 client.Close()
 ```
 
-
-
-# Notes
+## Notes
 - `GroupID` and `URL` are mandatory options when you initialize the SDK, you can call `dataproxy.WithGroupID()` and 
   `dataproxy.WithURL()` to set them;
 -  When you initialize more the one instance of `Client`, the `MetricsName` must be set to different values, or it will be failed when pulling metrics, you can call `dataproxy.WithMetricsName()` to set it;
@@ -101,7 +102,7 @@ client.Close()
 - The SDK will retry 2 times each message, if it still failed finally, it is up to you to decide what to do next.
 
 ## Errors
-Some common errors
+Some common errors:
 
 | Error                                                       | Desc                                       |
 | ------------------------------------------------------------ | ------------------------------------------- |

--- a/docs/sdk/dataproxy-sdk/go.md
+++ b/docs/sdk/dataproxy-sdk/go.md
@@ -1,0 +1,169 @@
+---
+title: Go SDK
+sidebar_position: 4
+---
+
+import {siteVariables} from '../../version';
+
+## Create real-time synchronization task
+Create a task on the Dashboard or with the command line tool, and set `Auto Push` (autonomous push) as the data source type.
+
+## Import Go SDK
+To use the Go SDK, you need to import it into your projects. Import the Go SDK:
+
+```go
+import "github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy"
+```
+
+
+
+
+## Data report process
+After importing the SDK, you can initialize a [Client](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go) instance, and then call `Send()` or `SendAsync()` to produce messages to DataProxy, SDK will put the messages with a same StreamID into a batch and send them together. A demo can be found at: [example_test.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/example_test.go).
+Basically, there are 3 steps to produce messages:
+
+### Initialize the SDK
+```go
+client, err := dataproxy.NewClient(
+	dataproxy.WithGroupID("test"),		      	
+dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList"),
+	dataproxy.WithMetricsName("test"),
+)
+
+if err != nil {
+	fmt.Println(err)
+	return
+}
+```
+
+### Call the Send/SendAsync method to send
+The send methods of the SDK are goroutine safe, you can send a message synchronously or asynchronously, there are both synchronous and asynchronous examples in the demo.
+
+Send synchronously :
+
+```go
+for i := 0; i < 1000; i++ {
+    err := client.Send(context.Background(), dataproxy.Message{
+		GroupID:  "test",
+		StreamID: "test",
+		Payload:  []byte("test|a|b|c"),
+	})
+    if err !=nil {
+        fmt.Println(err)
+    }
+}
+```
+
+Send asynchronously:
+
+```go
+var success atomic.Uint64
+var failed atomic.Uint64
+for i := 0; i < 1000; i++ {
+	client.SendAsync(context.Background(),
+		dataproxy.Message{
+			GroupID:  "test",
+			StreamID: "test",
+			Payload:  []byte("test|a|b|c"),
+		},
+		func(msg dataproxy.Message, err error) {
+			if err != nil {
+				success.Add(1)
+			} else {
+				failed.Add(1)
+			}
+		})
+}
+
+// wait async send finish
+time.Sleep(3 * time.Second)
+fmt.Println("success:", success.Load())
+fmt.Println("failed:", failed.Load())
+```
+
+The asynchronous way is recommended, as the synchronous way has no concurrency, messages can be sent after the previous one is done or timeout, it can't fulfill your requirements when you need high throughput.
+
+### Close the SDK 
+Closing the SDK can be done simply by calling the  `Close()` method of the `Client`:
+
+```go
+client.Close()
+```
+
+
+
+# Notes
+- `GroupID` and `URL` are mandatory options when you initialize the SDK, you can call `dataproxy.WithGroupID()` and 
+  `dataproxy.WithURL()` to set them;
+-  When you initialize more the one instance of `Client`, the `MetricsName` must be set to different values, or it will be failed when pulling metrics, you can call `dataproxy.WithMetricsName()` to set it;
+- The default values of the config options of the SDK are good enough for production, you don't need the change then unless you really need to do that, the default values are described in a section below;
+- The `Send()` method of the SDK has no concurrent, messages are sent one by one, it is NOT recommended;
+- The SDK will retry 2 times each message, if it still failed finally, it is up to you to decide what to do next.
+
+## Errors
+Some common errors
+
+| Error                                                       | Desc                                       |
+| ------------------------------------------------------------ | ------------------------------------------- |
+| errors.New("URL is not given")                               | Service registry URL is not set.                                |
+| errors.New("group ID is not given")                          | Group ID is not set.                                |
+| errors.New("invalid URL")                                    | Service registry URL is invalid.                            |
+| errors.New("invalid group ID")                               | Group ID is invalid.                                |
+| errors.New("service has no endpoints")                       | Service has no endpoints, service discoery failed.                        |
+| errors.New("no available worker")                            | No available workers, workers are busy.                              |
+| errNo{code: 10001, strCode: "10001", message: "message send timeout"} | Send timeout. |
+| errNo{code: 10002, strCode: "10002", message: "message send failed"} | Send failed.                                   |
+| errNo{code: 10003, strCode: "10003", message: "producer already been closed"} | Producer is closed.                                   |
+| errNo{code: 10004, strCode: "10004", message: "producer send queue is full"} | Send queue is full, return immediately.                                 |
+| errNo{code: 10005, strCode: "10005", message: "message context expired"} | Send queue is full, enqueue timeout.            |
+| errNo{code: 10010, strCode: "10010", message: "input log is invalid"} | Input message is invalid, the payload may be empty.                              |
+
+## Config options
+
+| Option                      | Default value                | Desc                                                         | Optional                                                     |
+| --------------------------- | ---------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| WithSet()                   | ""                           | Sets the cluster name.                                        | Yes, no use now.                                                   |
+| WithGroupID()               | ""                           | Sets the Group ID.                                            | No                                                           |
+| WithURL()                   | ""                           | Sets the service registry URL.                                | No                                                           |
+| WithUpdateInterval()        | 5m                           | Sets the update interval of service discoery.                 | Yes                                                           |
+| WithConnTimeout()           | 3000ms                       | Sets the connection timeout.                                  | Yes                                                           |
+| WriteBufferSize             | 16M                          | Sets the write buffer size.                                   | Yes                                                           |
+| WithReadBufferSize          | 16M                          | Sets the read buffer size.                                    | Yes                                                           |
+| WithSocketSendBufferSize    | 16M                          | Sets the socket send buffer size.                             | Yes                                                           |
+| WithSocketRecvBufferSize    | 16M                          | Sets the socket receive buffer size.                          | Yes                                                           |
+| WithBufferPool              | nil                          | Sets the buffer pool to use.                                  | Yes, if the application has one, use the same one is recommended.                                     |
+| WithBytePool                | nil                          | Sets the byte pool to use.                                   | Yes, if the application has one, use the same one is recommended.                                    |
+| WithBufferPoolSize          | 409600                       | Sets the buffer pool size.                                   | Yes                                                           |
+| WithBytePoolSize            | 409600                       | Sets the byte pool size.                                     | Yes                                                           |
+| WithBytePoolWidth           | equals to BatchingMaxSize    | Sets the byte pool width.                                    | Yes                                                           |
+| WithLogger                  | std.out                      | Sets the debug logger.                                       | Yes, but the default one is not recommended, as it has no log levels control.                       |
+| WithMetricsName             | "dataproxy-go"               | Sets the metrics name of this client.                        | Yes, if there are more than one client instance in one application, the metrics names must be different. |
+| WithMetricsRegistry         | prometheus.DefaultRegisterer | Sets the metrics registry.                                               | Yes                                                           |
+| WithWorkerNum               | 8                            | Sets the worker number.                                               | Yes                                                           |
+| WithSendTimeout             | 30000ms                      | Sets the send timeout.                                                 | Yes                                                           |
+| WithMaxRetries              | 2                            | Sets the max retry count.                                             | Yes                                                           |
+| WithBatchingMaxPublishDelay | 10ms                         | Sets how long a message to wait for batching.        | Yes                                                           |
+| WithBatchingMaxMessages     | 10                           | Sets the message number of a batch.                         | Yes                                                           |
+| WithBatchingMaxSize         | 4K                           | Sets the batch size in Bytes of a batch.                     | Yes                                                           |
+| WithMaxPendingMessages      | 409600                       | Sets the queue length of each worker.                        | Yes                                                           |
+| WithBlockIfQueueIsFull      | false                        | Sets if block if the queue is full.                          | Yes                                                           |
+| WithAddColumns              | nil                          | Sets the added columns to all the messages, DataProxy supports add addtional columns at specific positions to all messages，for example:\_\_addcol1\_\_worldid=xxx will add a column named 'worldid' at position 1 and its value is 'xxx'. | Yes                                                           |
+
+options refers to [options.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/opitons.go)
+
+## Metrics
+
+| Name                         | Type      | Labels                                                         | Desc                                                         |
+| ---------------------------- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| data_proxy_error_count       | counter   | name: name we set with WithMetricsName()<br />code: error code | count the errors and the error code.                         |
+| data_proxy_retry_count       | counter   | name: name we set with WithMetricsName()<br />worker: worker index | count the retry messages and the worker's index.             |
+| data_proxy_timeout_count     | counter   | name: name we set with WithMetricsName()<br />worker: worker index | count the timeout messages and the worker's index.           |
+| data_proxy_msg_count         | counter   | name: name we set with WithMetricsName()<br />code: error code | count the message handled and error code.                    |
+| data_proxy_update_conn_count | counter   | name: name we set with WithMetricsName()<br />code: error code | count the connection update/switch times and error code. when error code is '0', it is a normal update, otherwise, it may be network error. |
+| data_proxy_pending_msg_gauge | gauge     | name: name we set with WithMetricsName()<br />worker: error code | count the pending message in each worker and the worker index. |
+| data_proxy_batch_size        | histogram | name: name we set with WithMetricsName()<br />code: error code | distribution of the batch size and the error code.           |
+| data_proxy_batch_time        | histogram | name: name we set with WithMetricsName()<br />code: error code | distribution of the batch send time duration and the error code. |
+
+metrics refers to [metrics.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/metrics.go)
+
+error codes refers to [worker.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go)

--- a/docs/sdk/dataproxy-sdk/go.md
+++ b/docs/sdk/dataproxy-sdk/go.md
@@ -34,9 +34,9 @@ if err != nil {
 
 where:
 
-- dataproxy.WithGroupID("test") sets the GroupID;
-- dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList") sets the service registry URL;
-- dataproxy.WithMetricsName("test") sets the value of the metrics label: "name" of the `Client`.
+- `dataproxy.WithGroupID("test")` sets the GroupID;
+- `dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList")` sets the service registry URL;
+- `dataproxy.WithMetricsName("test")` sets the value of the metrics label: "name" of the `Client`.
 
 ### Call the Send/SendAsync method to send
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.7.0/sdk/dataproxy-sdk/go.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.7.0/sdk/dataproxy-sdk/go.md
@@ -34,9 +34,9 @@ if err != nil {
 
 参数说明：
 
-- dataproxy.WithGroupID("test") 设置了 GroupID ；
-- dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList") 设置了服务注册中心的 URL ；
-- dataproxy.WithMetricsName("test") 设置了这个 `Client` 的指标中标签 "name" 的值；
+- `dataproxy.WithGroupID("test")` 设置了 GroupID ；
+- `dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList")` 设置了服务注册中心的 URL ；
+- `dataproxy.WithMetricsName("test")` 设置了这个 `Client` 的指标中标签 "name" 的值；
 
 ### 调用发送接口进行数据上报
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.7.0/sdk/dataproxy-sdk/go.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.7.0/sdk/dataproxy-sdk/go.md
@@ -1,0 +1,169 @@
+---
+title: Go SDK
+sidebar_position: 4
+---
+
+import {siteVariables} from '../../version';
+
+## 新建实时同步任务
+在 Dashboard 或者通过命令行工具创建任务，数据源类型使用 `Auto Push` (自主推送)。
+
+## 引入 Go SDK
+需要在项目中导入SDK 的包，进行 SDK 的使用。导入方式如下：
+
+```go
+import "github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy"
+```
+
+
+
+
+## 数据上报流程
+导入 SDK 后，通过实例化一个[Client](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go)接口对象后，调用相关的同步（`Send()`）或 异步（`SendAsync()`）接口来完成单条数据的上报任务，SDK内部会根据StreamID将相同StreamID的数据批量上报。发送Demo可参考 [example_test.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/example_test.go)。
+整体流程包括以下三个步骤：
+
+### 初始化 SDK
+```go
+client, err := dataproxy.NewClient(
+	dataproxy.WithGroupID("test"),		      	
+dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList"),
+	dataproxy.WithMetricsName("test"),
+)
+
+if err != nil {
+	fmt.Println(err)
+	return
+}
+```
+
+### 调用发送接口进行数据上报
+SDK 的数据发送接口是协程安全的，支持以同步或者异步模式发送单条数据。Demo里有同步的方式，也有异步的方式。
+
+同步方式：
+
+```go
+for i := 0; i < 1000; i++ {
+    err := client.Send(context.Background(), dataproxy.Message{
+		GroupID:  "test",
+		StreamID: "test",
+		Payload:  []byte("test|a|b|c"),
+	})
+    if err !=nil {
+        fmt.Println(err)
+    }
+}
+```
+
+异步方式：
+
+```go
+var success atomic.Uint64
+var failed atomic.Uint64
+for i := 0; i < 1000; i++ {
+	client.SendAsync(context.Background(),
+		dataproxy.Message{
+			GroupID:  "test",
+			StreamID: "test",
+			Payload:  []byte("test|a|b|c"),
+		},
+		func(msg dataproxy.Message, err error) {
+			if err != nil {
+				success.Add(1)
+			} else {
+				failed.Add(1)
+			}
+		})
+}
+
+// wait async send finish
+time.Sleep(3 * time.Second)
+fmt.Println("success:", success.Load())
+fmt.Println("failed:", failed.Load())
+```
+
+我们推荐使用异步的方式发送，因为同步方式是无并发的，调用发送请求后需要等到响应或者超时，才能发下一条，在需要高吞吐量的场景是无法满足需求的。
+
+### 关闭 SDK 
+关闭SDK只需要简单的调用`Close()`方法：
+
+```go
+client.Close()
+```
+
+
+
+# 注意事项
+- `GroupID`和`URL`是SDK初始化必选的配置，你可以使用`dataproxy.WithGroupID()`和
+  `dataproxy.WithURL()`来设置这些配置；
+- 当你在一个进程里初始化多个`Client`时，`MetricsName`必须配置不同的名称，否则指标查询将会失败，你可以使用`dataproxy.WithMetricsName()`来设置它；
+- SDK 的默认配置已经能够满足运营需求，除非你需要调大或者调小配置，一般不需要更改其他配置，配置的默认值请参考后面的章节；
+- SDK 的同步发送方法`Send()`是无并发的，在发送一个消息后，需要等待响应或者等待到超时才会返回，非必要的情况下不建议使用同步方法；
+- SDK 默认会对消息进行2次重传，如果依然失败，需要调用者来决定如何做下一步处理。
+
+## 错误
+常见错误如下：
+
+| 错误                                                         | 描述                               |
+| ------------------------------------------------------------ | ---------------------------------- |
+| errors.New("URL is not given")                               | 服务发现URL未设置。                |
+| errors.New("group ID is not given")                          | GroupID未设置。                    |
+| errors.New("invalid URL")                                    | 服务发现URL非法，可能为空。        |
+| errors.New("invalid group ID")                               | GroupID非法，可能为空。            |
+| errors.New("service has no endpoints")                       | 服务无端点，服务发现失败           |
+| errors.New("no available worker")                            | 没有可用工作者，工作者忙。         |
+| errNo{code: 10001, strCode: "10001", message: "message send timeout"} | 发送超时。                         |
+| errNo{code: 10002, strCode: "10002", message: "message send failed"} | 发送失败。                         |
+| errNo{code: 10003, strCode: "10003", message: "producer already been closed"} | 生产者已关闭。                     |
+| errNo{code: 10004, strCode: "10004", message: "producer send queue is full"} | 发送队列满。                       |
+| errNo{code: 10005, strCode: "10005", message: "message context expired"} | 发送队列满，超时都未等到空闲位置。 |
+| errNo{code: 10010, strCode: "10010", message: "input log is invalid"} | 输入的数据非法，可能为空。         |
+
+## 配置项
+
+| 配置项                      | 默认值                       | 描述                                                         | 可选                                                         |
+| --------------------------- | ---------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| WithSet()                   | ""                           | 设置集群名                                                   | 是，无用途                                                   |
+| WithGroupID()               | ""                           | 设置GroupID                                                  | 否                                                           |
+| WithURL()                   | ""                           | 设置服务发现的URL                                            | 否                                                           |
+| WithUpdateInterval()        | 5m                           | 设置服务发现的更新时间                                       | 是                                                           |
+| WithConnTimeout()           | 3000ms                       | 设置连接超时                                                 | 是                                                           |
+| WriteBufferSize             | 16M                          | 设置写缓冲区大小                                             | 是                                                           |
+| WithReadBufferSize          | 16M                          | 设置读缓冲区大小                                             | 是                                                           |
+| WithSocketSendBufferSize    | 16M                          | 设置网络发送缓冲区大小                                       | 是                                                           |
+| WithSocketRecvBufferSize    | 16M                          | 设置网络接收缓冲区大小                                       | 是                                                           |
+| WithBufferPool              | nil                          | 设置缓冲池                                                   | 是，如果应用有，建议共用                                     |
+| WithBytePool                | nil                          | 设置内存池                                                   | 是，如果应用有，建议共用                                     |
+| WithBufferPoolSize          | 409600                       | 设置缓冲池大小                                               | 是                                                           |
+| WithBytePoolSize            | 409600                       | 设置内存池大小                                               | 是                                                           |
+| WithBytePoolWidth           | 同BatchingMaxSize            | 设置内存池宽度                                               | 是                                                           |
+| WithLogger                  | std.out                      | 设置调试日志                                                 | 是，不建议，默认的日志没有日志级别控制                       |
+| WithMetricsName             | "dataproxy-go"               | 设置指标名                                                   | 是，如果一个应用实例化了多个client，必须配置不一样的指标名，否则指标获取会失败 |
+| WithMetricsRegistry         | prometheus.DefaultRegisterer | 设置指标存储器                                               | 是                                                           |
+| WithWorkerNum               | 8                            | 设置工作者数量                                               | 是                                                           |
+| WithSendTimeout             | 30000ms                      | 设置发送超时                                                 | 是                                                           |
+| WithMaxRetries              | 2                            | 设置量大重试次数                                             | 是                                                           |
+| WithBatchingMaxPublishDelay | 10ms                         | 设置消息发送延迟，超过该时间，不能构成一个批次也会发送       | 是                                                           |
+| WithBatchingMaxMessages     | 10                           | 设置批次消息条数，达到条数即批量发送                         | 是                                                           |
+| WithBatchingMaxSize         | 4K                           | 设置批次大小，达到该大小即批量发送                           | 是                                                           |
+| WithMaxPendingMessages      | 409600                       | 设置每个工作者队列大小                                       | 是                                                           |
+| WithBlockIfQueueIsFull      | false                        | 设置队列满是否阻塞                                           | 是                                                           |
+| WithAddColumns              | nil                          | 设置附加字段，DataProxy支持在消息指定的位置增加字段，如\_\_addcol1\_\_worldid=xxx表示所有的消息的第一列都是worldid，值为xxx的 | 是                                                           |
+
+配置项请参考[options.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options.go)
+
+## 指标
+
+| 指标名                       | 类型      | 标签                             | 描述                           |
+| ---------------------------- | --------- | -------------------------------- | ------------------------------ |
+| data_proxy_error_count       | counter   | name：名称<br />code：错误码     | 统计发生的错误次数及错误码     |
+| data_proxy_retry_count       | counter   | name：名称<br />worker：工作者ID | 统计发生的重试次数及工作者ID   |
+| data_proxy_timeout_count     | counter   | name：名称<br />worker：工作者ID | 统计发生的超时次数及工作者ID   |
+| data_proxy_msg_count         | counter   | name：名称<br />code：错误码     | 统计处理的消息数量和处理结果   |
+| data_proxy_update_conn_count | counter   | name：名称<br />code：错误码     | 统计发生的连接更新次数和错误码 |
+| data_proxy_pending_msg_gauge | gauge     | name：名称<br />worker：工作者ID | 统计排队中的消息数量及工作者ID |
+| data_proxy_batch_size        | histogram | name：名称<br />code：错误码     | 统计每个批次的大小和错误码     |
+| data_proxy_batch_time        | histogram | name：名称<br />code：错误码     | 统计每个批次的延迟和错误码     |
+
+指标请参考[metrics.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/metrics.go)
+
+错误码请参考[worker.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go)

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.7.0/sdk/dataproxy-sdk/go.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.7.0/sdk/dataproxy-sdk/go.md
@@ -35,7 +35,7 @@ if err != nil {
 参数说明：
 
 - `dataproxy.WithGroupID("test")` 设置了 GroupID ；
-- `dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList")` 设置了服务注册中心的 URL ；
+- `dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList")` 设置了 Manager 的 URL ；
 - `dataproxy.WithMetricsName("test")` 设置了这个 `Client` 的指标中标签 "name" 的值；
 
 ### 调用发送接口进行数据上报
@@ -106,9 +106,9 @@ client.Close()
 
 | 错误                                                         | 描述                               |
 | ------------------------------------------------------------ | ---------------------------------- |
-| errors.New("URL is not given")                               | 服务发现 URL  未设置。             |
+| errors.New("URL is not given")                               | Manager URL  未设置。             |
 | errors.New("group ID is not given")                          | GroupID未设置。                    |
-| errors.New("invalid URL")                                    | 服务发现 URL 非法，可能为空。      |
+| errors.New("invalid URL")                                    | Manager URL 非法，可能为空。      |
 | errors.New("invalid group ID")                               | GroupID 非法，可能为空。           |
 | errors.New("service has no endpoints")                       | 服务无端点，服务发现失败           |
 | errors.New("no available worker")                            | 没有可用工作者，工作者忙。         |
@@ -125,7 +125,7 @@ client.Close()
 | --------------------------- | ---------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | WithSet()                   | ""                           | 设置集群名                                                   | 是，无用途                                                   |
 | WithGroupID()               | ""                           | 设置GroupID                                                  | 否                                                           |
-| WithURL()                   | ""                           | 设置服务发现的URL                                            | 否                                                           |
+| WithURL()                   | ""                           | 设置 Manager 的URL                                            | 否                                                           |
 | WithUpdateInterval()        | 5m                           | 设置服务发现的更新时间                                       | 是                                                           |
 | WithConnTimeout()           | 3000ms                       | 设置连接超时                                                 | 是                                                           |
 | WriteBufferSize             | 16M                          | 设置写缓冲区大小                                             | 是                                                           |

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.7.0/sdk/dataproxy-sdk/go.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-1.7.0/sdk/dataproxy-sdk/go.md
@@ -1,25 +1,21 @@
 ---
-title: Go SDK
+title: Golang SDK
 sidebar_position: 4
 ---
-
-import {siteVariables} from '../../version';
 
 ## 新建实时同步任务
 在 Dashboard 或者通过命令行工具创建任务，数据源类型使用 `Auto Push` (自主推送)。
 
-## 引入 Go SDK
-需要在项目中导入SDK 的包，进行 SDK 的使用。导入方式如下：
+## 引入 Golang SDK
+需要在项目中导入 SDK 的包，进行 SDK 的使用。导入方式如下：
 
 ```go
 import "github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy"
 ```
 
 
-
-
 ## 数据上报流程
-导入 SDK 后，通过实例化一个[Client](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go)接口对象后，调用相关的同步（`Send()`）或 异步（`SendAsync()`）接口来完成单条数据的上报任务，SDK内部会根据StreamID将相同StreamID的数据批量上报。发送Demo可参考 [example_test.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/example_test.go)。
+导入 SDK 后，通过实例化一个 [Client](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go) 接口对象后，调用相关的同步（ `Send()` ）或 异步（ `SendAsync()` ）接口来完成单条数据的上报任务，SDK 内部会根据 StreamID 将相同 StreamID 的数据批量上报。发送 Demo 可参考 [example_test.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/example_test.go)。
 整体流程包括以下三个步骤：
 
 ### 初始化 SDK
@@ -36,8 +32,15 @@ if err != nil {
 }
 ```
 
+参数说明：
+
+- dataproxy.WithGroupID("test") 设置了 GroupID ；
+- dataproxy.WithURL("http://127.0.0.1:8083/inlong/manager/openapi/dataproxy/getIpList") 设置了服务注册中心的 URL ；
+- dataproxy.WithMetricsName("test") 设置了这个 `Client` 的指标中标签 "name" 的值；
+
 ### 调用发送接口进行数据上报
-SDK 的数据发送接口是协程安全的，支持以同步或者异步模式发送单条数据。Demo里有同步的方式，也有异步的方式。
+
+SDK 的数据发送接口是协程安全的，支持以同步或者异步模式发送单条数据。Demo 里有同步的方式，也有异步的方式。
 
 同步方式：
 
@@ -84,20 +87,18 @@ fmt.Println("failed:", failed.Load())
 我们推荐使用异步的方式发送，因为同步方式是无并发的，调用发送请求后需要等到响应或者超时，才能发下一条，在需要高吞吐量的场景是无法满足需求的。
 
 ### 关闭 SDK 
-关闭SDK只需要简单的调用`Close()`方法：
+关闭 SDK 只需要简单的调用 `Close()` 方法：
 
 ```go
 client.Close()
 ```
 
-
-
-# 注意事项
-- `GroupID`和`URL`是SDK初始化必选的配置，你可以使用`dataproxy.WithGroupID()`和
-  `dataproxy.WithURL()`来设置这些配置；
-- 当你在一个进程里初始化多个`Client`时，`MetricsName`必须配置不同的名称，否则指标查询将会失败，你可以使用`dataproxy.WithMetricsName()`来设置它；
+## 注意事项
+- `GroupID` 和 `URL` 是 SDK 初始化必选的配置，你可以使用 `dataproxy.WithGroupID()` 和 
+  `dataproxy.WithURL()` 来设置这些配置；
+- 当你在一个进程里初始化多个 `Client` 实例时，`MetricsName` 必须配置不同的名称，否则指标查询将会失败，你可以使用 `dataproxy.WithMetricsName()` 来设置它；
 - SDK 的默认配置已经能够满足运营需求，除非你需要调大或者调小配置，一般不需要更改其他配置，配置的默认值请参考后面的章节；
-- SDK 的同步发送方法`Send()`是无并发的，在发送一个消息后，需要等待响应或者等待到超时才会返回，非必要的情况下不建议使用同步方法；
+- SDK 的同步发送方法 `Send()` 是无并发的，在发送一个消息后，需要等待响应或者等待到超时才会返回，非必要的情况下不建议使用同步方法；
 - SDK 默认会对消息进行2次重传，如果依然失败，需要调用者来决定如何做下一步处理。
 
 ## 错误
@@ -105,10 +106,10 @@ client.Close()
 
 | 错误                                                         | 描述                               |
 | ------------------------------------------------------------ | ---------------------------------- |
-| errors.New("URL is not given")                               | 服务发现URL未设置。                |
+| errors.New("URL is not given")                               | 服务发现 URL  未设置。             |
 | errors.New("group ID is not given")                          | GroupID未设置。                    |
-| errors.New("invalid URL")                                    | 服务发现URL非法，可能为空。        |
-| errors.New("invalid group ID")                               | GroupID非法，可能为空。            |
+| errors.New("invalid URL")                                    | 服务发现 URL 非法，可能为空。      |
+| errors.New("invalid group ID")                               | GroupID 非法，可能为空。           |
 | errors.New("service has no endpoints")                       | 服务无端点，服务发现失败           |
 | errors.New("no available worker")                            | 没有可用工作者，工作者忙。         |
 | errNo{code: 10001, strCode: "10001", message: "message send timeout"} | 发送超时。                         |
@@ -137,7 +138,7 @@ client.Close()
 | WithBytePoolSize            | 409600                       | 设置内存池大小                                               | 是                                                           |
 | WithBytePoolWidth           | 同BatchingMaxSize            | 设置内存池宽度                                               | 是                                                           |
 | WithLogger                  | std.out                      | 设置调试日志                                                 | 是，不建议，默认的日志没有日志级别控制                       |
-| WithMetricsName             | "dataproxy-go"               | 设置指标名                                                   | 是，如果一个应用实例化了多个client，必须配置不一样的指标名，否则指标获取会失败 |
+| WithMetricsName             | "dataproxy-go"               | 设置指标名                                                   | 是，如果一个应用实例化了多个 client ，必须配置不一样的指标名，否则指标获取会失败 |
 | WithMetricsRegistry         | prometheus.DefaultRegisterer | 设置指标存储器                                               | 是                                                           |
 | WithWorkerNum               | 8                            | 设置工作者数量                                               | 是                                                           |
 | WithSendTimeout             | 30000ms                      | 设置发送超时                                                 | 是                                                           |
@@ -147,23 +148,23 @@ client.Close()
 | WithBatchingMaxSize         | 4K                           | 设置批次大小，达到该大小即批量发送                           | 是                                                           |
 | WithMaxPendingMessages      | 409600                       | 设置每个工作者队列大小                                       | 是                                                           |
 | WithBlockIfQueueIsFull      | false                        | 设置队列满是否阻塞                                           | 是                                                           |
-| WithAddColumns              | nil                          | 设置附加字段，DataProxy支持在消息指定的位置增加字段，如\_\_addcol1\_\_worldid=xxx表示所有的消息的第一列都是worldid，值为xxx的 | 是                                                           |
+| WithAddColumns              | nil                          | 设置附加字段，DataProxy 支持在消息指定的位置增加字段，如 \_\_addcol1\_\_worldid=xxx 表示所有的消息的第一列都是 worldid，值为 xxx 的 | 是                                                           |
 
-配置项请参考[options.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options.go)
+配置项请参考 [options.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options.go)
 
 ## 指标
 
-| 指标名                       | 类型      | 标签                             | 描述                           |
-| ---------------------------- | --------- | -------------------------------- | ------------------------------ |
-| data_proxy_error_count       | counter   | name：名称<br />code：错误码     | 统计发生的错误次数及错误码     |
-| data_proxy_retry_count       | counter   | name：名称<br />worker：工作者ID | 统计发生的重试次数及工作者ID   |
-| data_proxy_timeout_count     | counter   | name：名称<br />worker：工作者ID | 统计发生的超时次数及工作者ID   |
-| data_proxy_msg_count         | counter   | name：名称<br />code：错误码     | 统计处理的消息数量和处理结果   |
-| data_proxy_update_conn_count | counter   | name：名称<br />code：错误码     | 统计发生的连接更新次数和错误码 |
-| data_proxy_pending_msg_gauge | gauge     | name：名称<br />worker：工作者ID | 统计排队中的消息数量及工作者ID |
-| data_proxy_batch_size        | histogram | name：名称<br />code：错误码     | 统计每个批次的大小和错误码     |
-| data_proxy_batch_time        | histogram | name：名称<br />code：错误码     | 统计每个批次的延迟和错误码     |
+| 指标名                       | 类型      | 标签                              | 描述                             |
+| ---------------------------- | --------- | --------------------------------- | -------------------------------- |
+| data_proxy_error_count       | counter   | name：名称<br />code：错误码      | 统计发生的错误次数及错误码       |
+| data_proxy_retry_count       | counter   | name：名称<br />worker：工作者 ID | 统计发生的重试次数及工作者 ID    |
+| data_proxy_timeout_count     | counter   | name：名称<br />worker：工作者 ID | 统计发生的超时次数及工作者ID     |
+| data_proxy_msg_count         | counter   | name：名称<br />code：错误码      | 统计处理的消息数量和处理结果     |
+| data_proxy_update_conn_count | counter   | name：名称<br />code：错误码      | 统计发生的连接更新次数和错误码   |
+| data_proxy_pending_msg_gauge | gauge     | name：名称<br />worker：工作者 ID | 统计排队中的消息数量及工作者  ID |
+| data_proxy_batch_size        | histogram | name：名称<br />code：错误码      | 统计每个批次的大小和错误码       |
+| data_proxy_batch_time        | histogram | name：名称<br />code：错误码      | 统计每个批次的延迟和错误码       |
 
-指标请参考[metrics.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/metrics.go)
+指标请参考 [metrics.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/metrics.go)
 
-错误码请参考[worker.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go)
+错误码请参考 [worker.go](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go)


### PR DESCRIPTION
### [INLONG-WEBSITE-764][DataProxy] Add Golang SDK documents

- Fixes #764

### Motivation

I have push a PR to add an INLONG DataProxy Golang SDK, and here adds the relative documents.

### Modifications

Add docs/sdk/dataproxy-sdk/go.md
Add i18n/zh-CN/docusaurus-plugin-content-docs/version-1.7.0/sdk/dataproxy-sdk/go.md

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
 - Merge the PR files.
 - Verify if the newly added file can be showed on the website.

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why? This is a documents PR.
