### PR TITLE
[INLONG-768][Sort] Fix SQLServer key name of metadataKeys describe error

### DIFF
--- a/docs/data_node/extract_node/sqlserver-cdc.md
+++ b/docs/data_node/extract_node/sqlserver-cdc.md
@@ -209,22 +209,22 @@ The following format metadata can be exposed as read-only (VIRTUAL) columns in a
   </thead>
   <tbody>
     <tr>
-      <td>meta.table_name</td>
+      <td>table_name</td>
       <td>STRING NOT NULL</td>
       <td>Name of the table that contain the row.</td>
     </tr>   
      <tr>
-      <td>meta.schema_name</td>
+      <td>schema_name</td>
       <td>STRING NOT NULL</td>
       <td>Name of the schema that contain the row.</td>
     </tr>
     <tr>
-      <td>meta.database_name</td>
+      <td>database_name</td>
       <td>STRING NOT NULL</td>
       <td>Name of the database that contain the row.</td>
     </tr>
     <tr>
-      <td>meta.op_ts</td>
+      <td>op_ts</td>
       <td>TIMESTAMP_LTZ(3) NOT NULL</td>
       <td>It indicates the time that the change was made in the database. <br/>If the record is read from snapshot of the table instead of the binlog, the value is always 0.</td>
     </tr>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/sqlserver-cdc.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/sqlserver-cdc.md
@@ -210,22 +210,22 @@ TODO
   </thead>
   <tbody>
     <tr>
-      <td>meta.table_name</td>
+      <td>table_name</td>
       <td>STRING NOT NULL</td>
       <td>包含该行的表的名称。</td>
     </tr>   
      <tr>
-      <td>meta.schema_name</td>
+      <td>schema_name</td>
       <td>STRING NOT NULL</td>
       <td>包含该行 schema 的名称。</td>
     </tr>
     <tr>
-      <td>meta.database_name</td>
+      <td>database_name</td>
       <td>STRING NOT NULL</td>
       <td>包含该行数据库的名称。</td>
     </tr>
     <tr>
-      <td>meta.op_ts</td>
+      <td>op_ts</td>
       <td>TIMESTAMP_LTZ(3) NOT NULL</td>
       <td>它表示在数据库中进行更改的时间。如果记录是从表的快照而不是 binlog 中读取的，则该值始终为 0。</td>
     </tr>


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-768][Sort] Fix SQLServer key name of metadataKeys describe error

- Fixes #768 

### Motivation

Fix SQLServer key name of metadataKeys describe error. From the code, the metadata fields of SQL Server only include `table_name`, `schema_name`, `database_name`, and `op_ts`.

<img width="1671" alt="image" src="https://github.com/apache/inlong-website/assets/111486498/fc6b83e3-5d84-4889-b276-7136397f19dc">


### Modifications

Remove the prefix `meta.`.
