### PR TITLE
[INLONG-772][Doc] Update the http report guide

### DIFF
--- a/docs/sdk/dataproxy-sdk/http.md
+++ b/docs/sdk/dataproxy-sdk/http.md
@@ -17,7 +17,7 @@ curl -X POST -d 'groupId=give_your_group_id&streamId=give_your_stream_id&dt=data
 | groupId   | Data stream group id                  |         |
 | streamId  | Data stream ID                        |         |
 | body      | Data content to be pushed             |         |
-| dt        | Data time to be pushed                |         |
+| dt        | Data time to be pushed                |timestamp millisecond     |
 | cnt       | The count of data pieces to be pushed |         |
 
 - Return Value：

--- a/docs/sdk/dataproxy-sdk/http.md
+++ b/docs/sdk/dataproxy-sdk/http.md
@@ -17,7 +17,7 @@ curl -X POST -d 'groupId=give_your_group_id&streamId=give_your_stream_id&dt=data
 | groupId   | Data stream group id                  |         |
 | streamId  | Data stream ID                        |         |
 | body      | Data content to be pushed             |         |
-| dt        | Data time to be pushed                |timestamp millisecond     |
+| dt        | Data time to be pushed                |timestamp in millisecond     |
 | cnt       | The count of data pieces to be pushed |         |
 
 - Return Value：

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/sdk/dataproxy-sdk/http.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/sdk/dataproxy-sdk/http.md
@@ -17,7 +17,7 @@ curl -X POST -d 'groupId=give_your_group_id&streamId=give_your_stream_id&dt=data
 | groupId  | 数据流组 id  |     |
 | streamId | 数据流 ID   |     |
 | body     | 推送的数据内容  |     |
-| dt       | 推送的数据时间  |     |
+| dt       | 推送的数据时间  |毫秒为单位的时间戳 |
 | cnt      | 推送条数     |     |
 
 - 返回值：


### PR DESCRIPTION
the dt param should be emphasized to be a time stamp in inlong web side http report example

### Prepare a Pull Request
* Update the http report guide*

- Fixes #772 

### Motivation

*the dt param should be emphasized to be a time stamp in inlong web side http report example*

### Modifications

*update the http report guide*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
