### PR TITLE
[INLONG-823] Fix Database Tips for standalone deployment mode

### DIFF
--- a/docs/deployment/standalone.md
+++ b/docs/deployment/standalone.md
@@ -39,7 +39,7 @@ In `conf/inlong.conf`, configure the parameters according to the actual situatio
 local_ip=
 # message queue: pulsar or kafka
 mq_type=pulsar
-# Configure Database, MySQL or PostgreSQL
+# Configure Database, requires MySQL
 spring_datasource_hostname=
 spring_datasource_port=3306
 spring_datasource_username=root

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/standalone.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/deployment/standalone.md
@@ -39,7 +39,7 @@ inlong-tubemq-manager/lib/
 local_ip=
 # 消息队列服务： pulsar 或者 kafka
 mq_type=pulsar
-# 数据库配置，MySQL 或者 PostgreSQL
+# 数据库配置，需要使用 MySQL
 spring_datasource_hostname=
 spring_datasource_port=3306
 spring_datasource_username=root


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #823 

### Motivation

Delete PostgreSQL, which is not support in inlong start script.

### Modifications

Delete PostgreSQL tips.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
