### PR TITLE
[INLONG-840][Doc] Adding more details to the tubemq-manager documentation

### DIFF
--- a/docs/modules/tubemq/tubemq-manager/quick_start.md
+++ b/docs/modules/tubemq/tubemq-manager/quick_start.md
@@ -15,7 +15,7 @@ mysql -uDB_USER -pDB_PASSWD < sql/apache_tube_manager.sql
   
 ## Configuration
 ```ini
-# mysql configuration for manager
+# MySQL configuration for Manager
 spring.datasource.url=jdbc:mysql://mysql_ip:mysql_port/apache_tube_manager
 spring.datasource.username=mysql_username
 spring.datasource.password=mysql_password

--- a/docs/modules/tubemq/tubemq-manager/quick_start.md
+++ b/docs/modules/tubemq/tubemq-manager/quick_start.md
@@ -14,15 +14,15 @@ mysql -uDB_USER -pDB_PASSWD < sql/apache_tube_manager.sql
 ````
   
 ## Configuration
-- Add mysql information in conf/application.properties (you can directly use the database you just imported via sql/apache_tube_manager.sql)
-
+- create `apache_tube_manager` and account in MySQL.
+- Add mysql information in conf/application.properties:
 ```ini
 # mysql configuration for manager
 spring.datasource.url=jdbc:mysql://mysql_ip:mysql_port/apache_tube_manager
 spring.datasource.username=mysql_username
 spring.datasource.password=mysql_password
 
-# If you are on JDK version 11+, add the following extra, otherwise ignore it
+# If you are on JDK version 11+, add the following extra
 spring.jaxb-compatibility-mode=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
@@ -39,15 +39,13 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 - If the backend database is PostgreSQL, there's no need for additional dependencies.
 
 ## Start
-- Start the manager service as configured above
 ``` bash
 $ bin/start-manager.sh 
 ```
 ## Restart
-- If you change the mysql configuration in the applications.properties file midway through the process, you need to shut down and restart the manager service for the new configuration to take effect.
+- When you change the configuration above
 ``` bash
-$ bin/stop-manager.sh 
-$ bin/start-manager.sh 
+$ bin/restart-manager.sh 
 ```
 
 ## Register TubeMQ cluster

--- a/docs/modules/tubemq/tubemq-manager/quick_start.md
+++ b/docs/modules/tubemq/tubemq-manager/quick_start.md
@@ -14,8 +14,6 @@ mysql -uDB_USER -pDB_PASSWD < sql/apache_tube_manager.sql
 ````
   
 ## Configuration
-- create `apache_tube_manager` and account in MySQL.
-- Add mysql information in conf/application.properties:
 ```ini
 # mysql configuration for manager
 spring.datasource.url=jdbc:mysql://mysql_ip:mysql_port/apache_tube_manager
@@ -42,6 +40,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 ``` bash
 $ bin/start-manager.sh 
 ```
+
 ## Restart
 ``` bash
 $ bin/restart-manager.sh 

--- a/docs/modules/tubemq/tubemq-manager/quick_start.md
+++ b/docs/modules/tubemq/tubemq-manager/quick_start.md
@@ -43,7 +43,6 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 $ bin/start-manager.sh 
 ```
 ## Restart
-- When you change the configuration above
 ``` bash
 $ bin/restart-manager.sh 
 ```

--- a/docs/modules/tubemq/tubemq-manager/quick_start.md
+++ b/docs/modules/tubemq/tubemq-manager/quick_start.md
@@ -23,7 +23,6 @@ spring.datasource.password=mysql_password
 # If you are on JDK version 11+, add the following extra
 spring.jaxb-compatibility-mode=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-
 ```
 
 ## Dependencies

--- a/docs/modules/tubemq/tubemq-manager/quick_start.md
+++ b/docs/modules/tubemq/tubemq-manager/quick_start.md
@@ -14,14 +14,18 @@ mysql -uDB_USER -pDB_PASSWD < sql/apache_tube_manager.sql
 ````
   
 ## Configuration
-- create `tubemanager` and account in MySQL.
-- Add mysql information in conf/application.properties:
+- Add mysql information in conf/application.properties (you can directly use the database you just imported via sql/apache_tube_manager.sql)
 
 ```ini
 # mysql configuration for manager
-spring.datasource.url=jdbc:mysql://mysql_ip:mysql_port/tubemanager
+spring.datasource.url=jdbc:mysql://mysql_ip:mysql_port/apache_tube_manager
 spring.datasource.username=mysql_username
 spring.datasource.password=mysql_password
+
+# If you are on JDK version 11+, add the following extra, otherwise ignore it
+spring.jaxb-compatibility-mode=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
 ```
 
 ## Dependencies
@@ -35,8 +39,14 @@ spring.datasource.password=mysql_password
 - If the backend database is PostgreSQL, there's no need for additional dependencies.
 
 ## Start
-
+- Start the manager service as configured above
 ``` bash
+$ bin/start-manager.sh 
+```
+## Restart
+- If you change the mysql configuration in the applications.properties file midway through the process, you need to shut down and restart the manager service for the new configuration to take effect.
+``` bash
+$ bin/stop-manager.sh 
 $ bin/start-manager.sh 
 ```
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/tubemq-manager/quick_start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/tubemq-manager/quick_start.md
@@ -14,8 +14,6 @@ mysql -uDB_USER -pDB_PASSWD < sql/apache_tube_manager.sql
 ```
   
 ## 配置
-- 在mysql中创建`apache_tube_manager`数据和相应用户.
-- 在conf/application.properties中添加mysql信息：
 
 ```ini
 # mysql configuration for manager
@@ -41,7 +39,8 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 ``` bash
 $ bin/start-manager.sh 
 ```
-## 重新启动
+
+## 重启
 ``` bash
 $ bin/restart-manager.sh 
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/tubemq-manager/quick_start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/tubemq-manager/quick_start.md
@@ -42,7 +42,6 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 $ bin/start-manager.sh 
 ```
 ## 重新启动
-- 当你更改了上文配置
 ``` bash
 $ bin/restart-manager.sh 
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/tubemq-manager/quick_start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/tubemq-manager/quick_start.md
@@ -14,14 +14,18 @@ mysql -uDB_USER -pDB_PASSWD < sql/apache_tube_manager.sql
 ```
   
 ## 配置
-- 在mysql中创建`tubemanager`数据和相应用户.
+- 在mysql中创建`apache_tube_manager`数据和相应用户.
 - 在conf/application.properties中添加mysql信息：
 
 ```ini
 # mysql configuration for manager
-spring.datasource.url=jdbc:mysql://mysql_ip:mysql_port/tubemanager
+spring.datasource.url=jdbc:mysql://mysql_ip:mysql_port/apache_tube_manager
 spring.datasource.username=mysql_username
 spring.datasource.password=mysql_password
+
+# 如果您使用的是 JDK 11+ 版本，请额外添加以下内容
+spring.jaxb-compatibility-mode=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 ```
 
 ### 依赖
@@ -36,6 +40,11 @@ spring.datasource.password=mysql_password
 
 ``` bash
 $ bin/start-manager.sh 
+```
+## 重新启动
+- 当你更改了上文配置
+``` bash
+$ bin/restart-manager.sh 
 ```
 
 ## 初始化TubeMQ集群

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/tubemq-manager/quick_start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/tubemq-manager/quick_start.md
@@ -15,7 +15,7 @@ mysql -uDB_USER -pDB_PASSWD < sql/apache_tube_manager.sql
   
 ## 配置
 ```ini
-# mysql configuration for manager
+# MySQL configuration for Manager
 spring.datasource.url=jdbc:mysql://mysql_ip:mysql_port/apache_tube_manager
 spring.datasource.username=mysql_username
 spring.datasource.password=mysql_password

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/tubemq-manager/quick_start.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/tubemq/tubemq-manager/quick_start.md
@@ -14,7 +14,6 @@ mysql -uDB_USER -pDB_PASSWD < sql/apache_tube_manager.sql
 ```
   
 ## 配置
-
 ```ini
 # mysql configuration for manager
 spring.datasource.url=jdbc:mysql://mysql_ip:mysql_port/apache_tube_manager


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #840

### Motivation

**Some parts of the original document are easily misleading to users, it has been modified and supplemented.**

### Modifications

**1、the previous text has been imported sql file, configuration instructions here, can be changed to:
-Add mysql information in conf/application.properties (you can directly use the database imported through sql/apache_tube_manager.sql)


2、Start the manager service according to the configuration above. If you change the applications.properties file in the middle of the process, you need to shut down and restart the manager service for the new configuration to take effect.**

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
