### PR TITLE
[INLONG-873][Release] Update how-to-verify doc to use correct test command

### DIFF
--- a/community/how-to-verify.md
+++ b/community/how-to-verify.md
@@ -49,7 +49,7 @@ Unzip `apache-inlong-${release_version}-src.tar.gz` and check the following:
 - Whether the single test can run through
 
 :::note
-You can check the compilation and unit test through `mvn clean package install`. If the compilation fails, clean up the local warehouse first.
+You can check the compilation and UTs through `mvn clean package install -DskipTests && mvn test`. If the compilation fails, clean up the local warehouse first.
 :::
 
 ### Check binary packages

--- a/community/how-to-verify.md
+++ b/community/how-to-verify.md
@@ -49,7 +49,7 @@ Unzip `apache-inlong-${release_version}-src.tar.gz` and check the following:
 - Whether the single test can run through
 
 :::note
-You can check the compilation and UTs through `mvn clean package install -DskipTests && mvn test`. If the compilation fails, clean up the local warehouse first.
+You can check the compilation and UTs through `mvn clean package install -DskipTests && mvn test`. If the compilation fails, clean up the local repository first.
 :::
 
 ### Check binary packages

--- a/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/how-to-verify.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs-community/current/how-to-verify.md
@@ -49,7 +49,7 @@ for i in *.tar.gz; do echo $i; gpg --verify $i.asc $i ; done
 - 单测是否能够跑通
 
 :::note
-可以通过 `mvn clean package install` 检查编译和单测，如果编译失败，先清理掉本地仓库。
+可以通过 `mvn clean package install -DskipTests && mvn test` 检查编译和单测，如果编译失败，先清理掉本地仓库。
 :::
 
 ### 检查二进制包


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #873 

### Motivation

Mvn clean package would run test before install

Sometimes we need to install first to run some tests

So install -DskipTests first and then use mvn test to run tests

### Modifications

install -DskipTests first and then use mvn test to run tests
