### PR TITLE
Update document of TubeMQ extract node and HBase load node

### DIFF
--- a/docs/data_node/extract_node/tube.md
+++ b/docs/data_node/extract_node/tube.md
@@ -46,9 +46,9 @@ Flink SQL> CREATE TABLE tube_extract_node (
      ) WITH (
      'connector' = 'tubemq',
      'topic' = 'topicName',
-     'masterRpc' = 'rpcUrl', -- 127.0.0.1:8715
+     'master.rpc' = 'rpcUrl', -- 127.0.0.1:8715
      'format' = 'json',
-     'groupId' = 'groupName');
+     'group.id' = 'groupName');
   
 -- Read data from tube_extract_node
 Flink SQL> SELECT * FROM tube_extract_node;

--- a/docs/data_node/load_node/hbase.md
+++ b/docs/data_node/load_node/hbase.md
@@ -58,16 +58,16 @@ CREATE TABLE hbase_load_node (
 
 -- use ROW(...) construction function construct column families and write data into the HBase table.
 -- assuming the schema of "T" is [rowkey, f1q1, f2q2, f2q3, f3q4, f3q5, f3q6]
-INSERT INTO hTable
+INSERT INTO hbase_load_node
 SELECT rowkey, ROW(f1q1), ROW(f2q2, f2q3), ROW(f3q4, f3q5, f3q6) FROM T;
 
 -- scan data from the HBase table
-SELECT rowkey, family1, family3.q4, family3.q6 FROM hTable;
+SELECT rowkey, family1, family3.q4, family3.q6 FROM hbase_load_node;
 
 -- temporal join the HBase table as a dimension table
 SELECT * FROM myTopic
-LEFT JOIN hTable FOR SYSTEM_TIME AS OF myTopic.proctime
-ON myTopic.key = hTable.rowkey;
+LEFT JOIN hbase_load_node FOR SYSTEM_TIME AS OF myTopic.proctime
+ON myTopic.key = hbase_load_node.rowkey;
 ```
 
 ### Usage for InLong Dashboard

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/tube.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/tube.md
@@ -45,9 +45,9 @@ Flink SQL> CREATE TABLE tube_extract_node (
      ) WITH (
      'connector' = 'tubemq',
      'topic' = 'topicName',
-     'masterRpc' = 'rpcUrl', -- 127.0.0.1:8715
+     'master.rpc' = 'rpcUrl', -- 127.0.0.1:8715
      'format' = 'json',
-     'groupId' = 'groupName');
+     'group.id' = 'groupName');
   
 -- Read data from tube_extract_node
 Flink SQL> SELECT * FROM tube_extract_node;

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/load_node/hbase.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/load_node/hbase.md
@@ -56,16 +56,16 @@ CREATE TABLE hbase_load_node (
 
 -- 使用 ROW(...) 构造函数构造列族和写数据到 HBase 表。
 -- 假设表"T"的 schema [rowkey, f1q1, f2q2, f2q3, f3q4, f3q5, f3q6]
-INSERT INTO hTable
+INSERT INTO hbase_load_node
 SELECT rowkey, ROW(f1q1), ROW(f2q2, f2q3), ROW(f3q4, f3q5, f3q6) FROM T;
 
 -- 从 HBase 表中扫描数据
-SELECT rowkey, family1, family3.q4, family3.q6 FROM hTable;
+SELECT rowkey, family1, family3.q4, family3.q6 FROM hbase_load_node;
 
 -- 将 HBase 表临时连接为维度表
 SELECT * FROM myTopic
-LEFT JOIN hTable FOR SYSTEM_TIME AS OF myTopic.proctime
-ON myTopic.key = hTable.rowkey;
+LEFT JOIN hbase_load_node FOR SYSTEM_TIME AS OF myTopic.proctime
+ON myTopic.key = hbase_load_node.rowkey;
 ```
 
 ### InLong Dashboard 用法


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #877 
- Fixes #878 

### Motivation

TubeMQ Extract Node:
![image](https://github.com/apache/inlong-website/assets/47296299/d5ee4930-8224-4777-b096-3b5c7bb6cb99)
The problem is 'masterRpc' and 'groupId'.
Actually, according to follwing line, they should be 'master.rpc' and 'group.id'.
https://github.com/apache/inlong/blob/4802277803e2535ef072ae0d1d2ab6b8f5d0c991/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/TubeMQOptions.java#L107
https://github.com/apache/inlong/blob/4802277803e2535ef072ae0d1d2ab6b8f5d0c991/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/TubeMQOptions.java#L113

HBase Load Node:
![image](https://github.com/apache/inlong-website/assets/47296299/b02f2e75-af77-4dee-8bb9-e93f69ce9407)

The confusing 'hTable' should be 'hbase_load_node' in fact.

