### PR TITLE
[INLONG-877][Improve] Update document of TubeMQ extract node

### DIFF
--- a/docs/data_node/extract_node/tube.md
+++ b/docs/data_node/extract_node/tube.md
@@ -48,7 +48,7 @@ Flink SQL> CREATE TABLE tube_extract_node (
      'topic' = 'topicName',
      'master.rpc' = 'rpcUrl', -- 127.0.0.1:8715
      'format' = 'json',
-     'group.id' = 'groupName');
+     'group.name' = 'groupName');
   
 -- Read data from tube_extract_node
 Flink SQL> SELECT * FROM tube_extract_node;

--- a/docs/data_node/extract_node/tube.md
+++ b/docs/data_node/extract_node/tube.md
@@ -46,9 +46,9 @@ Flink SQL> CREATE TABLE tube_extract_node (
      ) WITH (
      'connector' = 'tubemq',
      'topic' = 'topicName',
-     'masterRpc' = 'rpcUrl', -- 127.0.0.1:8715
+     'master.rpc' = 'rpcUrl', -- 127.0.0.1:8715
      'format' = 'json',
-     'groupId' = 'groupName');
+     'group.id' = 'groupName');
   
 -- Read data from tube_extract_node
 Flink SQL> SELECT * FROM tube_extract_node;

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/tube.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/tube.md
@@ -45,9 +45,9 @@ Flink SQL> CREATE TABLE tube_extract_node (
      ) WITH (
      'connector' = 'tubemq',
      'topic' = 'topicName',
-     'masterRpc' = 'rpcUrl', -- 127.0.0.1:8715
+     'master.rpc' = 'rpcUrl', -- 127.0.0.1:8715
      'format' = 'json',
-     'groupId' = 'groupName');
+     'group.id' = 'groupName');
   
 -- Read data from tube_extract_node
 Flink SQL> SELECT * FROM tube_extract_node;

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/tube.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/data_node/extract_node/tube.md
@@ -47,7 +47,7 @@ Flink SQL> CREATE TABLE tube_extract_node (
      'topic' = 'topicName',
      'master.rpc' = 'rpcUrl', -- 127.0.0.1:8715
      'format' = 'json',
-     'group.id' = 'groupName');
+     'group.name' = 'groupName');
   
 -- Read data from tube_extract_node
 Flink SQL> SELECT * FROM tube_extract_node;


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #877 

### Motivation

*Update document of TubeMQ extract node*

### Modifications

*Update document of TubeMQ extract node*

According to these lines, `masterRpc` should be `master.rpc` and `groupId` should be `group.id`.
https://github.com/apache/inlong/blob/18c39ff593b1afb71063d85dc89adc4d589516cf/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/TubeMQOptions.java#L107
https://github.com/apache/inlong/blob/18c39ff593b1afb71063d85dc89adc4d589516cf/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/TubeMQOptions.java#L113

