### PR TITLE
[INLONG-1067][Doc] Add sqlserver and mongodb to supported list of newly-introduced source metrics

### DIFF
--- a/docs/modules/sort/metrics.md
+++ b/docs/modules/sort/metrics.md
@@ -38,13 +38,13 @@ Sort will export metric by flink metric group, So user can use [metric reporter]
 | groupId_streamId_nodeId_database_table_numBytesInPerSecond | mysql-cdc | input bytes number per second |
 | groupId_streamId_nodeId_database_schema_table_numBytesInPerSecond | oracle-cdc,postgresql-cdc | input bytes number per second |
 | groupId_streamId_nodeId_database_collection_numBytesInPerSecond | mongodb-cdc | input bytes number per second |
-| groupId_streamId_nodeId_database_collection_numSnapshotCreate | postgresql-cdc,pulsar | checkpoint creation attempt number | 
-| groupId_streamId_nodeId_database_collection_numSnapshotError | postgresql-cdc,pulsar | checkpoint creation exception number |
-| groupId_streamId_nodeId_database_collection_numSnapshotComplete | postgresql-cdc,pulsar | successful checkpoint creation number |
-| groupId_streamId_nodeId_database_collection_snapshotToCheckpointTimeLag | postgresql-cdc,pulsar | time lag from start to completion of checkpoint creation (ms) |
-| groupId_streamId_nodeId_database_collection_numDeserializeSuccess | postgresql-cdc,pulsar | successful deserialization number | 
-| groupId_streamId_nodeId_database_collection_numDeserializeError | postgresql-cdc,pulsar | deserialization error number | 
-| groupId_streamId_nodeId_database_collection_deserializeTimeLag | postgresql-cdc,pulsar | deserialization time lag (ms) |
+| groupId_streamId_nodeId_database_collection_numSnapshotCreate | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | checkpoint creation attempt number | 
+| groupId_streamId_nodeId_database_collection_numSnapshotError | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | checkpoint creation exception number |
+| groupId_streamId_nodeId_database_collection_numSnapshotComplete | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | successful checkpoint creation number |
+| groupId_streamId_nodeId_database_collection_snapshotToCheckpointTimeLag | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | time lag from start to completion of checkpoint creation (ms) |
+| groupId_streamId_nodeId_database_collection_numDeserializeSuccess | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | successful deserialization number | 
+| groupId_streamId_nodeId_database_collection_numDeserializeError | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | deserialization error number | 
+| groupId_streamId_nodeId_database_collection_deserializeTimeLag | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | deserialization time lag (ms) |
 ### Supporting load node
 
 #### Node level metric

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/sort/metrics.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/modules/sort/metrics.md
@@ -36,13 +36,13 @@ sidebar_position: 4
 | groupId_streamId_nodeId_database_table_numBytesInPerSecond | mysql-cdc | 每秒输入字节数 |
 | groupId_streamId_nodeId_database_schema_table_numBytesInPerSecond | oracle-cdc,postgresql-cdc | 每秒输入字节数 |
 | groupId_streamId_nodeId_database_collection_numBytesInPerSecond | mongodb-cdc | 每秒输入字节数 |
-| groupId_streamId_nodeId_database_collection_numSnapshotCreate | postgresql-cdc,pulsar | 尝试创建Checkpoint数 |
-| groupId_streamId_nodeId_database_collection_numSnapshotError | postgresql-cdc,pulsar | 创建Checkpoint异常数 |
-| groupId_streamId_nodeId_database_collection_numSnapshotComplete | postgresql-cdc,pulsar | 创建Checkpoint成功数 |
-| groupId_streamId_nodeId_database_collection_snapshotToCheckpointTimeLag | postgresql-cdc,pulsar | 从开始创建Checkpoint到完成创建延迟（毫秒） |
-| groupId_streamId_nodeId_database_collection_numDeserializeSuccess | postgresql-cdc,pulsar | 反序列化成功数 |
-| groupId_streamId_nodeId_database_collection_numDeserializeSuccess | postgresql-cdc,pulsar | 反序列化异常数 |
-| groupId_streamId_nodeId_database_collection_deserializeTimeLag | postgresql-cdc,pulsar | 反序列化延迟（毫秒） |
+| groupId_streamId_nodeId_database_collection_numSnapshotCreate | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | 尝试创建Checkpoint数 |
+| groupId_streamId_nodeId_database_collection_numSnapshotError | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | 创建Checkpoint异常数 |
+| groupId_streamId_nodeId_database_collection_numSnapshotComplete | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | 创建Checkpoint成功数 |
+| groupId_streamId_nodeId_database_collection_snapshotToCheckpointTimeLag | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | 从开始创建Checkpoint到完成创建延迟（毫秒） |
+| groupId_streamId_nodeId_database_collection_numDeserializeSuccess | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | 反序列化成功数 |
+| groupId_streamId_nodeId_database_collection_numDeserializeSuccess | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | 反序列化异常数 |
+| groupId_streamId_nodeId_database_collection_deserializeTimeLag | postgresql-cdc,pulsar,mongodb-cdc,sqlserver-cdc | 反序列化延迟（毫秒） |
 
 ### 支持的 load 节点
 


### PR DESCRIPTION
Fixes #1067 

### Motivation

Since changes to those above-mentioned cdcs are made during the release preparation of inlong, they are not included in release 2.0.0, but will be included in release 2.1.0 release. Adding documentation to reflect this change.

### Modifications


### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:
