### PR TITLE
[INLONG-1069][Doc] Add Connector Binary file v1.18 to download page

### DIFF
--- a/src/pages/downloads/index.js
+++ b/src/pages/downloads/index.js
@@ -96,6 +96,12 @@ export default function() {
                                                 <a target="_blank" className={styles.connectorDropdownItem} href={`https://repository.apache.org/content/groups/public/org/apache/inlong/inlong-distribution/${version}/inlong-distribution-${version}-sort-connectors-flink-v1.15.tar.gz.asc`}>ASC</a>
                                                 <a target="_blank" className={styles.connectorDropdownItem} href={`https://repository.apache.org/content/groups/public/org/apache/inlong/inlong-distribution/${version}/inlong-distribution-${version}-sort-connectors-flink-v1.15.tar.gz.sha512`}>SHA512</a>
                                             </div>
+                                            <div className={styles.connectorDropdownTwo}>
+                                                <span className={styles.connectorSpan}>v1.18:</span>
+                                                <a className={styles.connectorDropdownItem} href={`https://repository.apache.org/content/groups/public/org/apache/inlong/inlong-distribution/${version}/inlong-distribution-${version}-sort-connectors-flink-v1.18.tar.gz`}>BIN</a>
+                                                <a target="_blank" className={styles.connectorDropdownItem} href={`https://repository.apache.org/content/groups/public/org/apache/inlong/inlong-distribution/${version}/inlong-distribution-${version}-sort-connectors-flink-v1.18.tar.gz.asc`}>ASC</a>
+                                                <a target="_blank" className={styles.connectorDropdownItem} href={`https://repository.apache.org/content/groups/public/org/apache/inlong/inlong-distribution/${version}/inlong-distribution-${version}-sort-connectors-flink-v1.18.tar.gz.sha512`}>SHA512</a>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/src/pages/downloads/index.js
+++ b/src/pages/downloads/index.js
@@ -84,12 +84,6 @@ export default function() {
                                     </div>
                                     <div className={styles.buttonRow}>
                                         <div className={styles.buttonCard}>
-                                            <div className={styles.connectorDropdownOne}>
-                                                <span className={styles.connectorSpan}>v1.13:</span>
-                                                <a className={styles.connectorDropdownItem} href={`https://repository.apache.org/content/groups/public/org/apache/inlong/inlong-distribution/${version}/inlong-distribution-${version}-sort-connectors-flink-v1.13.tar.gz`}>BIN</a>
-                                                <a target="_blank" className={styles.connectorDropdownItem} href={`https://repository.apache.org/content/groups/public/org/apache/inlong/inlong-distribution/${version}/inlong-distribution-${version}-sort-connectors-flink-v1.13.tar.gz.asc`}>ASC</a>
-                                                <a target="_blank" className={styles.connectorDropdownItem} href={`https://repository.apache.org/content/groups/public/org/apache/inlong/inlong-distribution/${version}/inlong-distribution-${version}-sort-connectors-flink-v1.13.tar.gz.sha512`}>SHA512</a>
-                                            </div>
                                             <div className={styles.connectorDropdownTwo}>
                                                 <span className={styles.connectorSpan}>v1.15:</span>
                                                 <a className={styles.connectorDropdownItem} href={`https://repository.apache.org/content/groups/public/org/apache/inlong/inlong-distribution/${version}/inlong-distribution-${version}-sort-connectors-flink-v1.15.tar.gz`}>BIN</a>


### PR DESCRIPTION
Fixes #1069 

### Motivation
Connector Binary file v1.18 is not listed in download page. However, they have been released on the maven repository of apache inlong. It should be added to reflect this change, while also resolving confusions as some examples in the website require users to use connector-v1.18

### Modifications
Added one more row for Connector Binary file v1.18


### Verifying this change

![image](https://github.com/user-attachments/assets/dd5d797c-df4a-4e66-b102-c2b68d2588f2)

- [x] Make sure that the change passes the CI checks.


- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

