### PR TITLE
[INLONG-1074][Doc] Fix incorrect expression in Offline Data Synchronization example

### DIFF
--- a/docs/quick_start/offline_data_sync/pulsar_mysql_example.md
+++ b/docs/quick_start/offline_data_sync/pulsar_mysql_example.md
@@ -80,7 +80,7 @@ CREATE TABLE sink_table (
 );
 ```
 
-In the data sink section, click [Create] → [MySQL], and configure the data sink name, database name, and table name (test.source_table), among other information.
+In the data sink section, click [Create] → [MySQL], and configure the data sink name, database name, and table name (test.sink_table), among other information.
 
 ![Create Sink](img/pulsar_mysql/sink.png)
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick_start/offline_data_sync/pulsar_mysql_example.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick_start/offline_data_sync/pulsar_mysql_example.md
@@ -78,7 +78,7 @@ CREATE TABLE sink_table (
 );
 ```
 
-数据目标中 点击 【新建】→【MySQL】，配置数据源名称、库名和表名（test.source_table）等信息信息等。
+数据目标中 点击 【新建】→【MySQL】，配置数据目标名称、库名和表名（test.sink_table）等信息。
 
 ![Create Sink](img/pulsar_mysql/sink.png)
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0.0/quick_start/offline_data_sync/pulsar_mysql_example.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.0.0/quick_start/offline_data_sync/pulsar_mysql_example.md
@@ -78,7 +78,7 @@ CREATE TABLE sink_table (
 );
 ```
 
-数据目标中 点击 【新建】→【MySQL】，配置数据源名称、库名和表名（test.source_table）等信息信息等。
+数据目标中 点击 【新建】→【MySQL】，配置数据目标名称、库名和表名（test.sink_table）等信息。
 
 ![Create Sink](img/pulsar_mysql/sink.png)
 

--- a/versioned_docs/version-2.0.0/quick_start/offline_data_sync/pulsar_mysql_example.md
+++ b/versioned_docs/version-2.0.0/quick_start/offline_data_sync/pulsar_mysql_example.md
@@ -80,7 +80,7 @@ CREATE TABLE sink_table (
 );
 ```
 
-In the data sink section, click [Create] → [MySQL], and configure the data sink name, database name, and table name (test.source_table), among other information.
+In the data sink section, click [Create] → [MySQL], and configure the data sink name, database name, and table name (test.sink_table), among other information.
 
 ![Create Sink](img/pulsar_mysql/sink.png)
 


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #1074 

### Motivation

Revise the expression errors in the document.

### Modifications

Both Next and 2.0.0 have this issue. Taking the Next version as an example:
![image](https://github.com/user-attachments/assets/8bc73fd5-3041-4769-8c6a-cb858f0f3133)
![2](https://github.com/user-attachments/assets/6e19bbe4-ac9e-4c45-abf0-6138771c6233)


### Verifying this change

- [x] Make sure that the change passes the CI checks.
  *(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
    - *Added integration tests for end-to-end deployment with large payloads (10MB)*
    - *Extended integration test for recovery after broker failure*
